### PR TITLE
Fixing TLS certificate

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -248,13 +248,15 @@ const cert = new certificatemanager.Certificate(this, 'cert', {...});
 
 const node = new appmesh.VirtualNode(stack, 'node', {
   mesh,
-  dnsHostName: 'node',
+  serviceDiscovery: appmesh.ServiceDiscovery.dns('node'),
   listeners: [appmesh.VirtualNodeListener.grpc({
     port: 80,
-    tlsCertificate: appmesh.TlsCertificate.acm({
-      certificate: cert,
-      tlsMode: TlsMode.STRICT,
-    }),
+    tls: {
+      mode: TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.acm({
+        certificate: cert,
+      }),
+    },
   })],
 });
 
@@ -263,11 +265,13 @@ const gateway = new appmesh.VirtualGateway(this, 'gateway', {
   mesh: mesh,
   listeners: [appmesh.VirtualGatewayListener.grpc({
     port: 8080,
-    tlsCertificate: appmesh.TlsCertificate.file({
-      certificateChain: 'path/to/certChain',
-      privateKey: 'path/to/privateKey',
-      tlsMode: TlsMode.STRICT,
-    }),
+    tls: {
+      mode: TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.file({
+        certificateChainPath: 'path/to/certChain',
+        privateKeyPath: 'path/to/privateKey',
+      }),
+    },
   })],
   virtualGatewayName: 'gateway',
 });
@@ -309,7 +313,7 @@ connection pool properties per listener protocol types.
 // A Virtual Node with a gRPC listener with a connection pool set
 const node = new appmesh.VirtualNode(stack, 'node', {
   mesh,
-  dnsHostName: 'node',
+  serviceDiscovery: appmesh.ServiceDiscovery.dns('node'),
   listeners: [appmesh.VirtualNodeListener.http({
     port: 80,
     connectionPool: {

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -26,29 +26,34 @@ export enum TlsMode {
 }
 
 /**
- * A wrapper for the tls config returned by {@link TlsCertificate.bind}
+ * Represents TLS properties for listener
  */
-export interface TlsCertificateConfig {
+export interface TlsListener {
   /**
-   * The CFN shape for a listener TLS certificate
+   * Represents TLS certificate
    */
-  readonly tlsCertificate: CfnVirtualNode.ListenerTlsCertificateProperty,
+  readonly certificate: TlsCertificate;
 
   /**
    * The TLS mode.
    */
-  readonly tlsMode: TlsMode;
+  readonly mode: TlsMode;
+}
+
+/**
+ * A wrapper for the tls config returned by {@link TlsCertificate.bind}
+ */
+export interface TlsCertificateConfig {
+  /**
+   * The CFN shape for a TLS certificate
+   */
+  readonly tlsCertificate: CfnVirtualNode.ListenerTlsCertificateProperty,
 }
 
 /**
  * ACM Certificate Properties
  */
 export interface AcmCertificateOptions {
-  /**
-   * The TLS mode.
-   */
-  readonly tlsMode: TlsMode;
-
   /**
    * The ACM certificate
    */
@@ -59,11 +64,6 @@ export interface AcmCertificateOptions {
  * File Certificate Properties
  */
 export interface FileCertificateOptions {
-  /**
-   * The TLS mode.
-   */
-  readonly tlsMode: TlsMode;
-
   /**
    * The file path of the certificate chain file.
    */
@@ -105,20 +105,12 @@ export abstract class TlsCertificate {
  */
 class AcmTlsCertificate extends TlsCertificate {
   /**
-   * The TLS mode.
-   *
-   * @default - TlsMode.DISABLED
-   */
-  readonly tlsMode: TlsMode;
-
-  /**
    * The ARN of the ACM certificate
    */
   readonly acmCertificate: acm.ICertificate;
 
   constructor(props: AcmCertificateOptions) {
     super();
-    this.tlsMode = props.tlsMode;
     this.acmCertificate = props.certificate;
   }
 
@@ -129,7 +121,6 @@ class AcmTlsCertificate extends TlsCertificate {
           certificateArn: this.acmCertificate.certificateArn,
         },
       },
-      tlsMode: this.tlsMode,
     };
   }
 }
@@ -138,13 +129,6 @@ class AcmTlsCertificate extends TlsCertificate {
  * Represents a file provided TLS certificate
  */
 class FileTlsCertificate extends TlsCertificate {
-  /**
-   * The TLS mode.
-   *
-   * @default - TlsMode.DISABLED
-   */
-  readonly tlsMode: TlsMode;
-
   /**
    * The file path of the certificate chain file.
    */
@@ -157,7 +141,6 @@ class FileTlsCertificate extends TlsCertificate {
 
   constructor(props: FileCertificateOptions) {
     super();
-    this.tlsMode = props.tlsMode;
     this.certificateChain = props.certificateChainPath;
     this.privateKey = props.privateKeyPath;
   }
@@ -170,7 +153,6 @@ class FileTlsCertificate extends TlsCertificate {
           privateKey: this.privateKey,
         },
       },
-      tlsMode: this.tlsMode,
     };
   }
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
@@ -7,7 +7,7 @@ import {
   HttpConnectionPool,
   Protocol,
 } from './shared-interfaces';
-import { TlsCertificate, TlsCertificateConfig } from './tls-certificate';
+import { TlsListener } from './tls-certificate';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order
@@ -36,7 +36,7 @@ interface VirtualGatewayListenerCommonOptions {
    *
    * @default - none
    */
-  readonly tlsCertificate?: TlsCertificate;
+  readonly tls?: TlsListener;
 }
 
 /**
@@ -93,21 +93,21 @@ export abstract class VirtualGatewayListener {
    * Returns an HTTP Listener for a VirtualGateway
    */
   public static http(options: HttpGatewayListenerOptions = {}): VirtualGatewayListener {
-    return new VirtualGatewayListenerImpl(Protocol.HTTP, options.healthCheck, options.port, options.tlsCertificate, options.connectionPool);
+    return new VirtualGatewayListenerImpl(Protocol.HTTP, options.healthCheck, options.port, options.tls, options.connectionPool);
   }
 
   /**
    * Returns an HTTP2 Listener for a VirtualGateway
    */
   public static http2(options: Http2GatewayListenerOptions = {}): VirtualGatewayListener {
-    return new VirtualGatewayListenerImpl(Protocol.HTTP2, options.healthCheck, options.port, options.tlsCertificate, options.connectionPool);
+    return new VirtualGatewayListenerImpl(Protocol.HTTP2, options.healthCheck, options.port, options.tls, options.connectionPool);
   }
 
   /**
    * Returns a GRPC Listener for a VirtualGateway
    */
   public static grpc(options: GrpcGatewayListenerOptions = {}): VirtualGatewayListener {
-    return new VirtualGatewayListenerImpl(Protocol.GRPC, options.healthCheck, options.port, options.tlsCertificate, options.connectionPool);
+    return new VirtualGatewayListenerImpl(Protocol.GRPC, options.healthCheck, options.port, options.tls, options.connectionPool);
   }
 
   /**
@@ -125,7 +125,7 @@ class VirtualGatewayListenerImpl extends VirtualGatewayListener {
   constructor(private readonly protocol: Protocol,
     private readonly healthCheck: HealthCheck | undefined,
     private readonly port: number = 8080,
-    private readonly tlsCertificate: TlsCertificate | undefined,
+    private readonly tls: TlsListener | undefined,
     private readonly connectionPool: ConnectionPoolConfig | undefined) {
     super();
   }
@@ -135,7 +135,6 @@ class VirtualGatewayListenerImpl extends VirtualGatewayListener {
    * mutual exclusivity
    */
   public bind(scope: Construct): VirtualGatewayListenerConfig {
-    const tlsConfig = this.tlsCertificate?.bind(scope);
     return {
       listener: {
         portMapping: {
@@ -143,22 +142,23 @@ class VirtualGatewayListenerImpl extends VirtualGatewayListener {
           protocol: this.protocol,
         },
         healthCheck: this.healthCheck?.bind(scope, { defaultPort: this.port }).virtualGatewayHealthCheck,
-        tls: tlsConfig ? renderTls(tlsConfig) : undefined,
+        tls: renderTls(scope, this.tls),
         connectionPool: this.connectionPool ? renderConnectionPool(this.connectionPool, this.protocol) : undefined,
       },
     };
   }
-
 }
 
 /**
  * Renders the TLS config for a listener
  */
-function renderTls(tlsCertificateConfig: TlsCertificateConfig): CfnVirtualGateway.VirtualGatewayListenerTlsProperty {
-  return {
-    certificate: tlsCertificateConfig.tlsCertificate,
-    mode: tlsCertificateConfig.tlsMode.toString(),
-  };
+function renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualGateway.VirtualGatewayListenerTlsProperty | undefined {
+  return tls
+    ? {
+      certificate: tls.certificate.bind(scope).tlsCertificate,
+      mode: tls.mode,
+    }
+    : undefined;
 }
 
 function renderConnectionPool(connectionPool: ConnectionPoolConfig, listenerProtocol: Protocol):

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -5,7 +5,7 @@ import {
   GrpcConnectionPool, GrpcTimeout, Http2ConnectionPool, HttpConnectionPool,
   HttpTimeout, OutlierDetection, Protocol, TcpConnectionPool, TcpTimeout,
 } from './shared-interfaces';
-import { TlsCertificate, TlsCertificateConfig } from './tls-certificate';
+import { TlsListener } from './tls-certificate';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order
@@ -44,7 +44,7 @@ interface VirtualNodeListenerCommonOptions {
    *
    * @default - none
    */
-  readonly tlsCertificate?: TlsCertificate;
+  readonly tls?: TlsListener;
 
   /**
    * Represents the configuration for enabling outlier detection
@@ -134,7 +134,7 @@ export abstract class VirtualNodeListener {
    * Returns an HTTP Listener for a VirtualNode
    */
   public static http(props: HttpVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.HTTP, props.healthCheck, props.timeout, props.port, props.tlsCertificate, props.outlierDetection,
+    return new VirtualNodeListenerImpl(Protocol.HTTP, props.healthCheck, props.timeout, props.port, props.tls, props.outlierDetection,
       props.connectionPool);
   }
 
@@ -142,7 +142,7 @@ export abstract class VirtualNodeListener {
    * Returns an HTTP2 Listener for a VirtualNode
    */
   public static http2(props: Http2VirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.HTTP2, props.healthCheck, props.timeout, props.port, props.tlsCertificate, props.outlierDetection,
+    return new VirtualNodeListenerImpl(Protocol.HTTP2, props.healthCheck, props.timeout, props.port, props.tls, props.outlierDetection,
       props.connectionPool);
   }
 
@@ -150,7 +150,7 @@ export abstract class VirtualNodeListener {
    * Returns an GRPC Listener for a VirtualNode
    */
   public static grpc(props: GrpcVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.GRPC, props.healthCheck, props.timeout, props.port, props.tlsCertificate, props.outlierDetection,
+    return new VirtualNodeListenerImpl(Protocol.GRPC, props.healthCheck, props.timeout, props.port, props.tls, props.outlierDetection,
       props.connectionPool);
   }
 
@@ -158,7 +158,7 @@ export abstract class VirtualNodeListener {
    * Returns an TCP Listener for a VirtualNode
    */
   public static tcp(props: TcpVirtualNodeListenerOptions = {}): VirtualNodeListener {
-    return new VirtualNodeListenerImpl(Protocol.TCP, props.healthCheck, props.timeout, props.port, props.tlsCertificate, props.outlierDetection,
+    return new VirtualNodeListenerImpl(Protocol.TCP, props.healthCheck, props.timeout, props.port, props.tls, props.outlierDetection,
       props.connectionPool);
   }
 
@@ -173,12 +173,11 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
     private readonly healthCheck: HealthCheck | undefined,
     private readonly timeout: HttpTimeout | undefined,
     private readonly port: number = 8080,
-    private readonly tlsCertificate: TlsCertificate | undefined,
+    private readonly tls: TlsListener | undefined,
     private readonly outlierDetection: OutlierDetection | undefined,
     private readonly connectionPool: ConnectionPoolConfig | undefined) { super(); }
 
   public bind(scope: Construct): VirtualNodeListenerConfig {
-    const tlsConfig = this.tlsCertificate?.bind(scope);
     return {
       listener: {
         portMapping: {
@@ -187,7 +186,7 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
         },
         healthCheck: this.healthCheck?.bind(scope, { defaultPort: this.port }).virtualNodeHealthCheck,
         timeout: this.timeout ? this.renderTimeout(this.timeout) : undefined,
-        tls: tlsConfig ? this.renderTls(tlsConfig) : undefined,
+        tls: this.renderTls(scope, this.tls),
         outlierDetection: this.outlierDetection ? this.renderOutlierDetection(this.outlierDetection) : undefined,
         connectionPool: this.connectionPool ? this.renderConnectionPool(this.connectionPool) : undefined,
       },
@@ -197,11 +196,13 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
   /**
    * Renders the TLS config for a listener
    */
-  private renderTls(tlsCertificateConfig: TlsCertificateConfig): CfnVirtualNode.ListenerTlsProperty {
-    return {
-      certificate: tlsCertificateConfig.tlsCertificate,
-      mode: tlsCertificateConfig.tlsMode.toString(),
-    };
+  private renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualNode.ListenerTlsProperty | undefined {
+    return tls
+      ? {
+        certificate: tls.certificate.bind(scope).tlsCertificate,
+        mode: tls.mode,
+      }
+      : undefined;
   }
 
   private renderTimeout(timeout: HttpTimeout): CfnVirtualNode.ListenerTimeoutProperty {

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -207,11 +207,13 @@ new appmesh.VirtualGateway(stack, 'gateway2', {
     healthCheck: appmesh.HealthCheck.http({
       interval: cdk.Duration.seconds(10),
     }),
-    tlsCertificate: appmesh.TlsCertificate.file({
-      certificateChainPath: 'path/to/certChain',
-      privateKeyPath: 'path/to/privateKey',
-      tlsMode: appmesh.TlsMode.STRICT,
-    }),
+    tls: {
+      mode: appmesh.TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.file({
+        certificateChainPath: 'path/to/certChain',
+        privateKeyPath: 'path/to/privateKey',
+      }),
+    },
   })],
 });
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -169,10 +169,12 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.http({
           port: 8080,
-          tlsCertificate: appmesh.TlsCertificate.acm({
-            tlsMode: appmesh.TlsMode.STRICT,
-            certificate: cert,
-          }),
+          tls: {
+            mode: appmesh.TlsMode.STRICT,
+            certificate: appmesh.TlsCertificate.acm({
+              certificate: cert,
+            }),
+          },
         })],
       });
 
@@ -213,11 +215,13 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.grpc({
           port: 8080,
-          tlsCertificate: appmesh.TlsCertificate.file({
-            certificateChainPath: 'path/to/certChain',
-            privateKeyPath: 'path/to/privateKey',
-            tlsMode: appmesh.TlsMode.STRICT,
-          }),
+          tls: {
+            mode: appmesh.TlsMode.STRICT,
+            certificate: appmesh.TlsCertificate.file({
+              certificateChainPath: 'path/to/certChain',
+              privateKeyPath: 'path/to/privateKey',
+            }),
+          },
         })],
       });
 
@@ -257,11 +261,13 @@ export = {
         mesh: mesh,
         listeners: [appmesh.VirtualGatewayListener.grpc({
           port: 8080,
-          tlsCertificate: appmesh.TlsCertificate.file({
-            certificateChainPath: 'path/to/certChain',
-            privateKeyPath: 'path/to/privateKey',
-            tlsMode: appmesh.TlsMode.PERMISSIVE,
-          }),
+          tls: {
+            mode: appmesh.TlsMode.PERMISSIVE,
+            certificate: appmesh.TlsCertificate.file({
+              certificateChainPath: 'path/to/certChain',
+              privateKeyPath: 'path/to/privateKey',
+            }),
+          },
         })],
       });
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -437,16 +437,17 @@ export = {
           mesh,
           listeners: [appmesh.VirtualNodeListener.grpc({
             port: 80,
-            tlsCertificate: appmesh.TlsCertificate.acm({
-              certificate: cert,
-              tlsMode: appmesh.TlsMode.STRICT,
-            }),
+            tls: {
+              mode: appmesh.TlsMode.STRICT,
+              certificate: appmesh.TlsCertificate.acm({
+                certificate: cert,
+              }),
+            },
           },
           )],
         });
 
         // THEN
-
         expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
           Spec: {
             Listeners: [
@@ -484,11 +485,13 @@ export = {
           mesh,
           listeners: [appmesh.VirtualNodeListener.http({
             port: 80,
-            tlsCertificate: appmesh.TlsCertificate.file({
-              certificateChainPath: 'path/to/certChain',
-              privateKeyPath: 'path/to/privateKey',
-              tlsMode: appmesh.TlsMode.STRICT,
-            }),
+            tls: {
+              mode: appmesh.TlsMode.STRICT,
+              certificate: appmesh.TlsCertificate.file({
+                certificateChainPath: 'path/to/certChain',
+                privateKeyPath: 'path/to/privateKey',
+              }),
+            },
           })],
         });
 
@@ -529,11 +532,13 @@ export = {
           mesh,
           listeners: [appmesh.VirtualNodeListener.http({
             port: 80,
-            tlsCertificate: appmesh.TlsCertificate.file({
-              certificateChainPath: 'path/to/certChain',
-              privateKeyPath: 'path/to/privateKey',
-              tlsMode: appmesh.TlsMode.PERMISSIVE,
-            }),
+            tls: {
+              mode: appmesh.TlsMode.PERMISSIVE,
+              certificate: appmesh.TlsCertificate.file({
+                certificateChainPath: 'path/to/certChain',
+                privateKeyPath: 'path/to/privateKey',
+              }),
+            },
           })],
         });
 


### PR DESCRIPTION
### Note:
This is local team review only. Once it is reviewed by team and given green, I will place pull request to main repo.

### REV1:
- Updating `tls-certificate.ts` by:
  - Removing `tlsMode` property from `TlsCertificateConfig` since `tlsMode` is part of TLS listener's property.
  - Adding `TlsListener` interface
- Updating `virtual-node-listener.ts` and `virtual-gateway-listener.ts` files that depend on TLS certificate.
- Updating `README.md` file to reflect the change. In addition, fixing few discrepancies that were probably not reflected from previous updates.

### Design Note:
- Updating TLS certificate abstraction since this object is going to be used by client policy object ([example](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-virtualnode-clientpolicytls.html))
- Adding `TlsListener` interface to isolate TLS certificate object.

### Test:
- `yarn run build` and `yarn run test` successful.
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
