### PR TITLE
feat(appmesh) : implementing mutual TLS  feature

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -237,8 +237,11 @@ The `backendDefaults` property are added to the node while creating the virtual 
 
 ## Adding TLS to a listener
 
-The `tlsCertificate` property can be added to a Virtual Node listener or Virtual Gateway listener to add TLS configuration. 
-A certificate from AWS Certificate Manager can be incorporated or a customer provided certificate can be specified with a `certificateChain` path file and a `privateKey` file path.
+The `tls` property can be added to a Virtual Node listener or Virtual Gateway listener to add TLS configuration. 
+App Mesh allows you to provide the TLS certificate to the proxy in the following ways:
+* A certificate from AWS Certificate Manager can be incorporated
+* A customer provided certificate can be specified with a `certificateChain` path file and a `privateKey` file path.
+* A certificate provided by a Secrets Discovery Service (SDS) endpoint over local Unix Domain Socket can be specified with its `secretName`.
 
 ```typescript
 import * as certificatemanager from '@aws-cdk/aws-certificatemanager';
@@ -274,6 +277,62 @@ const gateway = new appmesh.VirtualGateway(this, 'gateway', {
     },
   })],
   virtualGatewayName: 'gateway',
+});
+```
+
+## Adding mutual TLS authentication
+
+To enable mutual TL authentication, add `certificate` property to TLS Client Policy and/or `validation` property to TLS Listener.
+
+A certificate from AWS Certificate Manager is **not** supported for mutual TLS.
+
+```typescript
+import * as certificatemanager from '@aws-cdk/aws-certificatemanager';
+
+// Validate a file client certificates to enable mutual TLS authentication when a client provides a certificate.
+const cert = new certificatemanager.Certificate(this, 'cert', {...});
+
+const node1 = new appmesh.VirtualNode(stack, 'node1', {
+  mesh,
+  serviceDiscovery: appmesh.ServiceDiscovery.dns('node'),
+  listeners: [appmesh.VirtualNodeListener.grpc({
+    port: 80,
+    tls: {
+      mode: appmesh.TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.acm({
+        certificate: cert,
+      }),
+      validation: {
+        trust: appmesh.TlsValidationTrust.file({
+          certificateChain: 'path-to-certificate',
+        }),
+      },
+    },
+  })],
+});
+
+// Provide a SDS client certificate when a server requests it and enable mutual TLS authentication.
+const certificateAuthorityArn = 'arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012';
+
+const node2 = new appmesh.VirtualNode(stack, 'node2', {
+  mesh,
+  serviceDiscovery: appmesh.ServiceDiscovery.dns('node'),
+  backendDefaults: {
+    tlsClientPolicy: {
+      certificate: appmesh.TlsCertificate.sds( {
+        secretName: 'secret_certificate',
+      }),
+      ports: [8080, 8081],
+      validation: {
+        subjectAlternativeNames: {
+          exactMatch: ['mesh-endpoint.apps.local'],
+        },
+        trust: appmesh.TlsValidationTrust.acm({
+          certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
+        }),
+      },
+    },
+  },
 });
 ```
 

--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -289,7 +289,6 @@ A certificate from AWS Certificate Manager is **not** supported for mutual TLS.
 ```typescript
 import * as certificatemanager from '@aws-cdk/aws-certificatemanager';
 
-// Validate a file client certificates to enable mutual TLS authentication when a client provides a certificate.
 const cert = new certificatemanager.Certificate(this, 'cert', {...});
 
 const node1 = new appmesh.VirtualNode(stack, 'node1', {
@@ -302,6 +301,7 @@ const node1 = new appmesh.VirtualNode(stack, 'node1', {
       certificate: appmesh.TlsCertificate.acm({
         certificate: cert,
       }),
+      // Validate a file client certificates to enable mutual TLS authentication when a client provides a certificate.
       validation: {
         trust: appmesh.TlsValidationTrust.file({
           certificateChain: 'path-to-certificate',
@@ -311,14 +311,14 @@ const node1 = new appmesh.VirtualNode(stack, 'node1', {
   })],
 });
 
-// Provide a SDS client certificate when a server requests it and enable mutual TLS authentication.
 const certificateAuthorityArn = 'arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012';
 
 const node2 = new appmesh.VirtualNode(stack, 'node2', {
   mesh,
-  serviceDiscovery: appmesh.ServiceDiscovery.dns('node'),
+  serviceDiscovery: appmesh.ServiceDiscovery.dns('node2'),
   backendDefaults: {
     tlsClientPolicy: {
+      // Provide a SDS client certificate when a server requests it and enable mutual TLS authentication.
       certificate: appmesh.TlsCertificate.sds( {
         secretName: 'secret_certificate',
       }),

--- a/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
@@ -51,7 +51,9 @@ export function renderTlsClientPolicy(scope: Construct, tlsClientPolicy: TlsClie
       validation: {
         subjectAlternativeNames: sans
           ? {
-            match: sans.bind(scope).subjectAlternativeNamesMatch,
+            match: {
+              exact: sans.exactMatch,
+            },
           }
           : undefined,
         trust: tlsClientPolicy.validation.trust.bind(scope).tlsValidationTrust,

--- a/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
@@ -1,6 +1,5 @@
 import { CfnVirtualNode } from '../appmesh.generated';
 import { TlsClientPolicy } from '../tls-client-policy';
-import { SubjectiveAlternativeNamesMatcherConfig, TlsValidationTrustConfig } from '../tls-validation';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order
@@ -35,11 +34,8 @@ export interface ConnectionPoolConfig {
 /**
  * This is the helper method to render TLS property of client policy.
  */
-export function renderTlsClientPolicy(scope: Construct, tlsClientPolicy: TlsClientPolicy | undefined,
-  trustExtractor: (c: TlsValidationTrustConfig) => CfnVirtualNode.TlsValidationContextTrustProperty,
-  sansExtractor: (c: SubjectiveAlternativeNamesMatcherConfig) => CfnVirtualNode.SubjectAlternativeNameMatchersProperty)
+export function renderTlsClientPolicy(scope: Construct, tlsClientPolicy: TlsClientPolicy | undefined)
   : CfnVirtualNode.ClientPolicyTlsProperty | undefined {
-
   const certificate = tlsClientPolicy?.certificate?.bind(scope).tlsCertificate;
   if (certificate?.acm) {
     throw new Error('ACM certificate source is currently not supported.');
@@ -55,10 +51,10 @@ export function renderTlsClientPolicy(scope: Construct, tlsClientPolicy: TlsClie
       validation: {
         subjectAlternativeNames: sans
           ? {
-            match: sansExtractor(sans.bind(scope)),
+            match: sans.bind(scope).subjectAlternativeNamesMatch,
           }
           : undefined,
-        trust: trustExtractor(tlsClientPolicy.validation.trust.bind(scope)),
+        trust: tlsClientPolicy.validation.trust.bind(scope).tlsValidationTrust,
       },
     }
     : undefined;

--- a/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/private/utils.ts
@@ -1,6 +1,6 @@
 import { CfnVirtualNode } from '../appmesh.generated';
 import { TlsClientPolicy } from '../tls-client-policy';
-import { TlsValidationTrustConfig } from '../tls-validation';
+import { SubjectiveAlternativeNamesMatcherConfig, TlsValidationTrustConfig } from '../tls-validation';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order
@@ -34,16 +34,31 @@ export interface ConnectionPoolConfig {
 
 /**
  * This is the helper method to render TLS property of client policy.
- *
  */
 export function renderTlsClientPolicy(scope: Construct, tlsClientPolicy: TlsClientPolicy | undefined,
-  extractor: (c: TlsValidationTrustConfig) => CfnVirtualNode.TlsValidationContextTrustProperty): CfnVirtualNode.ClientPolicyTlsProperty | undefined {
+  trustExtractor: (c: TlsValidationTrustConfig) => CfnVirtualNode.TlsValidationContextTrustProperty,
+  sansExtractor: (c: SubjectiveAlternativeNamesMatcherConfig) => CfnVirtualNode.SubjectAlternativeNameMatchersProperty)
+  : CfnVirtualNode.ClientPolicyTlsProperty | undefined {
+
+  const certificate = tlsClientPolicy?.certificate?.bind(scope).tlsCertificate;
+  if (certificate?.acm) {
+    throw new Error('ACM certificate source is currently not supported.');
+  }
+
+  const sans = tlsClientPolicy?.validation.subjectAlternativeNames;
+
   return tlsClientPolicy
     ? {
+      certificate: certificate,
       ports: tlsClientPolicy.ports,
       enforce: tlsClientPolicy.enforce,
       validation: {
-        trust: extractor(tlsClientPolicy.validation.trust.bind(scope)),
+        subjectAlternativeNames: sans
+          ? {
+            match: sansExtractor(sans.bind(scope)),
+          }
+          : undefined,
+        trust: trustExtractor(tlsClientPolicy.validation.trust.bind(scope)),
       },
     }
     : undefined;

--- a/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
@@ -241,7 +241,9 @@ class VirtualServiceBackend extends Backend {
           virtualServiceName: this.virtualService.virtualServiceName,
           clientPolicy: this.tlsClientPolicy
             ? {
-              tls: renderTlsClientPolicy(scope, this.tlsClientPolicy, (config) => config.virtualNodeClientTlsValidationTrust),
+              tls: renderTlsClientPolicy(scope, this.tlsClientPolicy,
+                (config) => config.virtualNodeClientTlsValidationTrust,
+                (config) => config.virtualNodeSans),
             }
             : undefined,
         },

--- a/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
@@ -241,9 +241,7 @@ class VirtualServiceBackend extends Backend {
           virtualServiceName: this.virtualService.virtualServiceName,
           clientPolicy: this.tlsClientPolicy
             ? {
-              tls: renderTlsClientPolicy(scope, this.tlsClientPolicy,
-                (config) => config.virtualNodeClientTlsValidationTrust,
-                (config) => config.virtualNodeSans),
+              tls: renderTlsClientPolicy(scope, this.tlsClientPolicy),
             }
             : undefined,
         },

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-certificate.ts
@@ -41,6 +41,16 @@ export interface FileCertificateOptions {
 }
 
 /**
+ * SDS Certificate Properties
+ */
+export interface SdsCertificateOptions {
+  /**
+   * The name of the secret for Envoy to fetch from a specific endpoint through the Secrets Discovery Protocol.
+   */
+  readonly secretName: string;
+}
+
+/**
  * Represents a TLS certificate
  */
 export abstract class TlsCertificate {
@@ -56,6 +66,13 @@ export abstract class TlsCertificate {
    */
   public static acm(props: AcmCertificateOptions): TlsCertificate {
     return new AcmTlsCertificate(props);
+  }
+
+  /**
+   * Returns an SDS TLS Certificate
+   */
+  public static sds(props: SdsCertificateOptions): TlsCertificate {
+    return new SdsTlsCertificate(props);
   }
 
   /**
@@ -116,6 +133,31 @@ class FileTlsCertificate extends TlsCertificate {
         file: {
           certificateChain: this.certificateChain,
           privateKey: this.privateKey,
+        },
+      },
+    };
+  }
+}
+
+/**
+ * Represents a SDS provided TLS certificate
+ */
+class SdsTlsCertificate extends TlsCertificate {
+  /**
+   * The name of the secret requested from the Secret Discovery Service provider.
+   */
+  readonly secretName: string;
+
+  constructor(props: SdsCertificateOptions) {
+    super();
+    this.secretName = props.secretName;
+  }
+
+  bind(_scope: Construct): TlsCertificateConfig {
+    return {
+      tlsCertificate: {
+        sds: {
+          secretName: this.secretName,
         },
       },
     };

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-client-policy.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-client-policy.ts
@@ -1,9 +1,18 @@
+import { TlsCertificate } from './tls-certificate';
 import { TlsValidation } from './tls-validation';
 
 /**
  * Represents the properties needed to define client policy
  */
 export interface TlsClientPolicy {
+  /**
+   * Represents a client's TLS certificate.
+   * Define this to enable mutual TLS authentication.
+   *
+   * @default - no TLS certificate
+   */
+  readonly certificate?: TlsCertificate;
+
   /**
    * Whether the policy is enforced.
    *

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-client-policy.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-client-policy.ts
@@ -6,10 +6,10 @@ import { TlsValidation } from './tls-validation';
  */
 export interface TlsClientPolicy {
   /**
-   * Represents a client's TLS certificate.
-   * Define this to enable mutual TLS authentication.
+   * Represents a client TLS certificate.
+   * The certificate will be sent only if the server requests it, enabling mutual TLS.
    *
-   * @default - no TLS certificate
+   * @default - client TLS certificate is not provided
    */
   readonly certificate?: TlsCertificate;
 

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-listener.ts
@@ -1,4 +1,5 @@
 import { TlsCertificate } from './tls-certificate';
+import { TlsValidation } from './tls-validation';
 
 /**
  * Enum of supported TLS modes
@@ -33,4 +34,12 @@ export interface TlsListener {
    * The TLS mode.
    */
   readonly mode: TlsMode;
+
+  /**
+   * Represents a listener's TLS validation context.
+   * Define this to enable mutual TLS authentication.
+   *
+   * @default - no TLS validation
+   */
+  readonly validation?: TlsValidation
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-listener.ts
@@ -37,9 +37,9 @@ export interface TlsListener {
 
   /**
    * Represents a listener's TLS validation context.
-   * Define this to enable mutual TLS authentication.
+   * The client certificate will only be validated if the client provides it, enabling mutual TLS.
    *
-   * @default - no TLS validation
+   * @default - client TLS certificate is not required
    */
   readonly validation?: TlsValidation
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
@@ -1,5 +1,5 @@
 import * as acmpca from '@aws-cdk/aws-acmpca';
-import { CfnVirtualGateway, CfnVirtualNode } from './appmesh.generated';
+import { CfnVirtualNode } from './appmesh.generated';
 
 // keep this import separate from other imports to reduce chance for merge conflicts with v2-main
 // eslint-disable-next-line no-duplicate-imports, import/order
@@ -166,47 +166,11 @@ class TlsValidationSdsTrust extends TlsValidationTrust {
 }
 
 /**
- * All Properties for Subject Alternative Names Matcher for both Client Policy and Listener.
+ * Represents the properties needed to define subject alternative names
  */
-export interface SubjectiveAlternativeNamesMatcherConfig {
-
-  /**
-   * VirtualNode CFN configuration for subject alternative names secured by the certificate.
-   */
-  readonly subjectAlternativeNamesMatch: CfnVirtualGateway.SubjectAlternativeNameMatchersProperty;
-}
-
-/**
- * Used to generate Subject Alternative Names Matchers
- */
-export abstract class SubjectiveAlternativeNames {
+export interface SubjectiveAlternativeNames {
   /**
    * The values of the SAN must match the specified values exactly.
-   *
-   * @param subjectAlternativeNames The exact values to test against.
    */
-  public static exactMatch(subjectAlternativeNames: string[]): SubjectiveAlternativeNames {
-    return new SubjectAlternativeNamesImpl({ exact: subjectAlternativeNames });
-  }
-
-  /**
-   * Returns Subject Alternative Names Matcher based on method type.
-   */
-  public abstract bind(scope: Construct): SubjectiveAlternativeNamesMatcherConfig;
+  readonly exactMatch: string[];
 }
-
-class SubjectAlternativeNamesImpl extends SubjectiveAlternativeNames {
-  constructor(
-    private readonly matchProperty: CfnVirtualNode.SubjectAlternativeNameMatchersProperty,
-  ) {
-    super();
-  }
-
-  public bind(_scope: Construct): SubjectiveAlternativeNamesMatcherConfig {
-    return {
-      subjectAlternativeNamesMatch: this.matchProperty,
-    };
-  }
-}
-
-

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
@@ -101,7 +101,7 @@ export abstract class TlsValidationTrust {
   }
 
   /**
-   * TLS Validation Context Trust for Enovoy' service discovery service.
+   * TLS Validation Context Trust for Envoy' service discovery service.
    */
   public static sds(props: TlsValidationSdsTrustOptions): TlsValidationTrust {
     return new TlsValidationSdsTrust(props);

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
@@ -30,26 +30,7 @@ export interface TlsValidationTrustConfig {
   /**
    * VirtualNode CFN configuration for client policy's TLS Validation Trust
    */
-  readonly virtualNodeClientTlsValidationTrust: CfnVirtualNode.TlsValidationContextTrustProperty;
-
-  /**
-   * VirtualNode CFN configuration for listener's TLS Validation Trust
-   *
-   * @default - no TLS Validation Trust
-   */
-  readonly virtualNodeListenerTlsValidationTrust?: CfnVirtualNode.ListenerTlsValidationContextTrustProperty
-
-  /**
-   * VirtualGateway CFN configuration for client policy's TLS Validation Trust
-   */
-  readonly virtualGatewayClientTlsValidationTrust: CfnVirtualGateway.VirtualGatewayTlsValidationContextTrustProperty;
-
-  /**
-   * VirtualGateway CFN configuration for listener's TLS Validation Trust
-   *
-   * @default - no TLS Validation Trust
-   */
-  readonly virtualGatewayListenerTlsValidationTrust?: CfnVirtualGateway.VirtualGatewayListenerTlsValidationContextTrustProperty;
+  readonly tlsValidationTrust: CfnVirtualNode.TlsValidationContextTrustProperty;
 }
 
 /**
@@ -129,13 +110,7 @@ class TlsValidationAcmTrust extends TlsValidationTrust {
       throw new Error('you must provide at least one Certificate Authority when creating an ACM Trust ClientPolicy');
     } else {
       return {
-        virtualNodeClientTlsValidationTrust: {
-          acm: {
-            certificateAuthorityArns: this.certificateAuthorities.map(certificateArn =>
-              certificateArn.certificateAuthorityArn),
-          },
-        },
-        virtualGatewayClientTlsValidationTrust: {
+        tlsValidationTrust: {
           acm: {
             certificateAuthorityArns: this.certificateAuthorities.map(certificateArn =>
               certificateArn.certificateAuthorityArn),
@@ -159,22 +134,7 @@ class TlsValidationFileTrust extends TlsValidationTrust {
 
   public bind(_scope: Construct): TlsValidationTrustConfig {
     return {
-      virtualNodeClientTlsValidationTrust: {
-        file: {
-          certificateChain: this.certificateChain,
-        },
-      },
-      virtualNodeListenerTlsValidationTrust: {
-        file: {
-          certificateChain: this.certificateChain,
-        },
-      },
-      virtualGatewayClientTlsValidationTrust: {
-        file: {
-          certificateChain: this.certificateChain,
-        },
-      },
-      virtualGatewayListenerTlsValidationTrust: {
+      tlsValidationTrust: {
         file: {
           certificateChain: this.certificateChain,
         },
@@ -196,22 +156,7 @@ class TlsValidationSdsTrust extends TlsValidationTrust {
 
   public bind(_scope: Construct): TlsValidationTrustConfig {
     return {
-      virtualNodeClientTlsValidationTrust: {
-        sds: {
-          secretName: this.secretName,
-        },
-      },
-      virtualNodeListenerTlsValidationTrust: {
-        sds: {
-          secretName: this.secretName,
-        },
-      },
-      virtualGatewayClientTlsValidationTrust: {
-        sds: {
-          secretName: this.secretName,
-        },
-      },
-      virtualGatewayListenerTlsValidationTrust: {
+      tlsValidationTrust: {
         sds: {
           secretName: this.secretName,
         },
@@ -228,12 +173,7 @@ export interface SubjectiveAlternativeNamesMatcherConfig {
   /**
    * VirtualNode CFN configuration for subject alternative names secured by the certificate.
    */
-  readonly virtualNodeSans: CfnVirtualGateway.SubjectAlternativeNameMatchersProperty;
-
-  /**
-   * VirtualGateway CFN configuration for subject alternative names secured by the certificate.
-   */
-  readonly virtualGatewaySans: CfnVirtualGateway.SubjectAlternativeNameMatchersProperty;
+  readonly subjectAlternativeNamesMatch: CfnVirtualGateway.SubjectAlternativeNameMatchersProperty;
 }
 
 /**
@@ -264,8 +204,7 @@ class SubjectAlternativeNamesImpl extends SubjectiveAlternativeNamesMatch {
 
   public bind(_scope: Construct): SubjectiveAlternativeNamesMatcherConfig {
     return {
-      virtualGatewaySans: this.matchProperty,
-      virtualNodeSans: this.matchProperty,
+      subjectAlternativeNamesMatch: this.matchProperty,
     };
   }
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/tls-validation.ts
@@ -15,7 +15,7 @@ export interface TlsValidation {
    *
    * @default - the Envoy proxy for that node doesn't verify the SAN on a peer client certificate.
    */
-  readonly subjectAlternativeNames?: SubjectiveAlternativeNamesMatch;
+  readonly subjectAlternativeNames?: SubjectiveAlternativeNames;
 
   /**
    * Reference to where to retrieve the trust chain.
@@ -179,13 +179,13 @@ export interface SubjectiveAlternativeNamesMatcherConfig {
 /**
  * Used to generate Subject Alternative Names Matchers
  */
-export abstract class SubjectiveAlternativeNamesMatch {
+export abstract class SubjectiveAlternativeNames {
   /**
    * The values of the SAN must match the specified values exactly.
    *
    * @param subjectAlternativeNames The exact values to test against.
    */
-  public static valuesAre(subjectAlternativeNames: string[]): SubjectiveAlternativeNamesMatch {
+  public static exactMatch(subjectAlternativeNames: string[]): SubjectiveAlternativeNames {
     return new SubjectAlternativeNamesImpl({ exact: subjectAlternativeNames });
   }
 
@@ -195,7 +195,7 @@ export abstract class SubjectiveAlternativeNamesMatch {
   public abstract bind(scope: Construct): SubjectiveAlternativeNamesMatcherConfig;
 }
 
-class SubjectAlternativeNamesImpl extends SubjectiveAlternativeNamesMatch {
+class SubjectAlternativeNamesImpl extends SubjectiveAlternativeNames {
   constructor(
     private readonly matchProperty: CfnVirtualNode.SubjectAlternativeNameMatchersProperty,
   ) {

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
@@ -166,7 +166,9 @@ function renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualGa
         ? {
           subjectAlternativeNames: tls.validation?.subjectAlternativeNames
             ? {
-              match: tls.validation.subjectAlternativeNames.bind(scope).subjectAlternativeNamesMatch,
+              match: {
+                exact: tls.validation.subjectAlternativeNames.exactMatch,
+              },
             }
             : undefined,
           trust: trustProperty,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
@@ -153,10 +153,25 @@ class VirtualGatewayListenerImpl extends VirtualGatewayListener {
  * Renders the TLS config for a listener
  */
 function renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualGateway.VirtualGatewayListenerTlsProperty | undefined {
+  const trustProperty = tls?.validation?.trust.bind(scope).virtualGatewayListenerTlsValidationTrust;
+  if (tls?.validation?.trust && !trustProperty) {
+    throw new Error('ACM certificate source is currently not supported.');
+  }
+
   return tls
     ? {
       certificate: tls.certificate.bind(scope).tlsCertificate,
       mode: tls.mode,
+      validation: trustProperty
+        ? {
+          subjectAlternativeNames: tls.validation?.subjectAlternativeNames
+            ? {
+              match: tls.validation.subjectAlternativeNames.bind(scope).virtualGatewaySans,
+            }
+            : undefined,
+          trust: trustProperty,
+        }
+        : undefined,
     }
     : undefined;
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway-listener.ts
@@ -153,8 +153,8 @@ class VirtualGatewayListenerImpl extends VirtualGatewayListener {
  * Renders the TLS config for a listener
  */
 function renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualGateway.VirtualGatewayListenerTlsProperty | undefined {
-  const trustProperty = tls?.validation?.trust.bind(scope).virtualGatewayListenerTlsValidationTrust;
-  if (tls?.validation?.trust && !trustProperty) {
+  const trustProperty = tls?.validation?.trust.bind(scope).tlsValidationTrust;
+  if (trustProperty?.acm) {
     throw new Error('ACM certificate source is currently not supported.');
   }
 
@@ -166,7 +166,7 @@ function renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualGa
         ? {
           subjectAlternativeNames: tls.validation?.subjectAlternativeNames
             ? {
-              match: tls.validation.subjectAlternativeNames.bind(scope).virtualGatewaySans,
+              match: tls.validation.subjectAlternativeNames.bind(scope).subjectAlternativeNamesMatch,
             }
             : undefined,
           trust: trustProperty,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
@@ -197,9 +197,7 @@ export class VirtualGateway extends VirtualGatewayBase {
         backendDefaults: props.backendDefaults !== undefined
           ? {
             clientPolicy: {
-              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy,
-                (config) => config.virtualGatewayClientTlsValidationTrust,
-                (config) => config.virtualGatewaySans),
+              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy),
             },
           }
           : undefined,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
@@ -197,7 +197,9 @@ export class VirtualGateway extends VirtualGatewayBase {
         backendDefaults: props.backendDefaults !== undefined
           ? {
             clientPolicy: {
-              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy, (config) => config.virtualGatewayClientTlsValidationTrust),
+              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy,
+                (config) => config.virtualGatewayClientTlsValidationTrust,
+                (config) => config.virtualGatewaySans),
             },
           }
           : undefined,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -197,10 +197,25 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
    * Renders the TLS config for a listener
    */
   private renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualNode.ListenerTlsProperty | undefined {
+    const trustProperty = tls?.validation?.trust.bind(scope).virtualNodeListenerTlsValidationTrust;
+    if (tls?.validation?.trust && !trustProperty) {
+      throw new Error('ACM certificate source is currently not supported.');
+    }
+
     return tls
       ? {
         certificate: tls.certificate.bind(scope).tlsCertificate,
         mode: tls.mode,
+        validation: trustProperty
+          ? {
+            subjectAlternativeNames: tls.validation?.subjectAlternativeNames
+              ? {
+                match: tls.validation.subjectAlternativeNames.bind(scope).virtualNodeSans,
+              }
+              : undefined,
+            trust: trustProperty,
+          }
+          : undefined,
       }
       : undefined;
   }

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -210,7 +210,9 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
           ? {
             subjectAlternativeNames: tlsValidation.subjectAlternativeNames
               ? {
-                match: tlsValidation.subjectAlternativeNames.bind(scope).subjectAlternativeNamesMatch,
+                match: {
+                  exact: tlsValidation.subjectAlternativeNames.exactMatch,
+                },
               }
               : undefined,
             trust: tlsValidation.trust.bind(scope).tlsValidationTrust,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -197,8 +197,8 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
    * Renders the TLS config for a listener
    */
   private renderTls(scope: Construct, tls: TlsListener | undefined): CfnVirtualNode.ListenerTlsProperty | undefined {
-    const trustProperty = tls?.validation?.trust.bind(scope).virtualNodeListenerTlsValidationTrust;
-    if (tls?.validation?.trust && !trustProperty) {
+    const tlsValidation = tls?.validation;
+    if (tlsValidation?.trust.bind(scope).tlsValidationTrust.acm) {
       throw new Error('ACM certificate source is currently not supported.');
     }
 
@@ -206,14 +206,14 @@ class VirtualNodeListenerImpl extends VirtualNodeListener {
       ? {
         certificate: tls.certificate.bind(scope).tlsCertificate,
         mode: tls.mode,
-        validation: trustProperty
+        validation: tlsValidation
           ? {
-            subjectAlternativeNames: tls.validation?.subjectAlternativeNames
+            subjectAlternativeNames: tlsValidation.subjectAlternativeNames
               ? {
-                match: tls.validation.subjectAlternativeNames.bind(scope).virtualNodeSans,
+                match: tlsValidation.subjectAlternativeNames.bind(scope).subjectAlternativeNamesMatch,
               }
               : undefined,
-            trust: trustProperty,
+            trust: tlsValidation.trust.bind(scope).tlsValidationTrust,
           }
           : undefined,
       }

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
@@ -200,9 +200,7 @@ export class VirtualNode extends VirtualNodeBase {
         backendDefaults: props.backendDefaults !== undefined
           ? {
             clientPolicy: {
-              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy,
-                (config) => config.virtualNodeClientTlsValidationTrust,
-                (config) => config.virtualNodeSans),
+              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy),
             },
           }
           : undefined,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
@@ -200,7 +200,9 @@ export class VirtualNode extends VirtualNodeBase {
         backendDefaults: props.backendDefaults !== undefined
           ? {
             clientPolicy: {
-              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy, (config) => config.virtualNodeClientTlsValidationTrust),
+              tls: renderTlsClientPolicy(this, props.backendDefaults?.tlsClientPolicy,
+                (config) => config.virtualNodeClientTlsValidationTrust,
+                (config) => config.virtualNodeSans),
             },
           }
           : undefined,

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -971,6 +971,30 @@
           "Backends": [
             {
               "VirtualService": {
+                "ClientPolicy": {
+                  "TLS": {
+                    "Certificate": {
+                      "File": {
+                        "CertificateChain": "path/to/certChain",
+                        "PrivateKey": "path/to/privateKey"
+                      }
+                    },
+                    "Validation": {
+                      "SubjectAlternativeNames": {
+                        "Match": {
+                          "Exact": [
+                            "mymesh.local"
+                          ]
+                        }
+                      },
+                      "Trust": {
+                        "File": {
+                          "CertificateChain": "path/to/certChain"
+                        }
+                      }
+                    }
+                  }
+                },
                 "VirtualServiceName": {
                   "Fn::GetAtt": [
                     "service3859EB104",
@@ -1060,6 +1084,96 @@
           }
         },
         "VirtualNodeName": "meshstackmeshnode3C5835BCB"
+      }
+    },
+    "meshnode4AE87F692": {
+      "Type": "AWS::AppMesh::VirtualNode",
+      "Properties": {
+        "MeshName": {
+          "Fn::GetAtt": [
+            "meshACDFE68E",
+            "MeshName"
+          ]
+        },
+        "Spec": {
+          "BackendDefaults": {
+            "ClientPolicy": {
+              "TLS": {
+                "Validation": {
+                  "Trust": {
+                    "File": {
+                      "CertificateChain": "path-to-certificate"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Backends": [
+            {
+              "VirtualService": {
+                "VirtualServiceName": {
+                  "Fn::GetAtt": [
+                    "service4983B61EE",
+                    "VirtualServiceName"
+                  ]
+                }
+              }
+            }
+          ],
+          "Listeners": [
+            {
+              "HealthCheck": {
+                "HealthyThreshold": 3,
+                "IntervalMillis": 5000,
+                "Path": "/check-path3",
+                "Port": 8080,
+                "Protocol": "http",
+                "TimeoutMillis": 2000,
+                "UnhealthyThreshold": 2
+              },
+              "PortMapping": {
+                "Port": 8080,
+                "Protocol": "http"
+              },
+              "TLS": {
+                "Certificate": {
+                  "SDS": {
+                    "SecretName": "spiffe://domain.local/backend-service"
+                  }
+                },
+                "Mode": "STRICT",
+                "Validation": {
+                  "SubjectAlternativeNames": {
+                    "Match": {
+                      "Exact": [
+                        "client.domain.local"
+                      ]
+                    }
+                  },
+                  "Trust": {
+                    "SDS": {
+                      "SecretName": "spiffe://domain.local"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "Logging": {
+            "AccessLog": {
+              "File": {
+                "Path": "/dev/stdout"
+              }
+            }
+          },
+          "ServiceDiscovery": {
+            "DNS": {
+              "Hostname": "node4.domain.local"
+            }
+          }
+        },
+        "VirtualNodeName": "meshstackmeshnode404B014E7"
       }
     },
     "meshgateway1B02387E8": {
@@ -1257,6 +1371,19 @@
         "VirtualServiceName": "service3.domain.local"
       }
     },
+    "service4983B61EE": {
+      "Type": "AWS::AppMesh::VirtualService",
+      "Properties": {
+        "MeshName": {
+          "Fn::GetAtt": [
+            "meshACDFE68E",
+            "MeshName"
+          ]
+        },
+        "Spec": {},
+        "VirtualServiceName": "service4.domain.local"
+      }
+    },
     "gateway2BCE5C5E0": {
       "Type": "AWS::AppMesh::VirtualGateway",
       "Properties": {
@@ -1295,6 +1422,71 @@
           ]
         },
         "VirtualGatewayName": "meshstackgateway2BEC62D7C"
+      }
+    },
+    "gateway3F9F16554": {
+      "Type": "AWS::AppMesh::VirtualGateway",
+      "Properties": {
+        "MeshName": {
+          "Fn::GetAtt": [
+            "meshACDFE68E",
+            "MeshName"
+          ]
+        },
+        "Spec": {
+          "BackendDefaults": {
+            "ClientPolicy": {
+              "TLS": {
+                "Certificate": {
+                  "File": {
+                    "CertificateChain": "path/to/certChain",
+                    "PrivateKey": "path/to/privateKey"
+                  }
+                },
+                "Validation": {
+                  "Trust": {
+                    "SDS": {
+                      "SecretName": "secret_validation"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Listeners": [
+            {
+              "HealthCheck": {
+                "HealthyThreshold": 2,
+                "IntervalMillis": 10000,
+                "Path": "/",
+                "Port": 443,
+                "Protocol": "http",
+                "TimeoutMillis": 2000,
+                "UnhealthyThreshold": 2
+              },
+              "PortMapping": {
+                "Port": 443,
+                "Protocol": "http"
+              },
+              "TLS": {
+                "Certificate": {
+                  "SDS": {
+                    "SecretName": "secret_certificate"
+                  }
+                },
+                "Mode": "STRICT",
+                "Validation": {
+                  "Trust": {
+                    "File": {
+                      "CertificateChain": "path/to/certChain"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "VirtualGatewayName": "meshstackgateway34EC5ED00"
       }
     }
   }

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -84,12 +84,28 @@ const node2 = mesh.addVirtualNode('node2', {
       },
     },
   },
-  backends: [appmesh.Backend.virtualService(
-    new appmesh.VirtualService(stack, 'service-3', {
-      virtualServiceName: 'service3.domain.local',
-      virtualServiceProvider: appmesh.VirtualServiceProvider.none(mesh),
-    }),
-  )],
+  backends: [
+    appmesh.Backend.virtualService(
+      new appmesh.VirtualService(stack, 'service-3', {
+        virtualServiceName: 'service3.domain.local',
+        virtualServiceProvider: appmesh.VirtualServiceProvider.none(mesh),
+      }),
+      {
+        tlsClientPolicy: {
+          certificate: appmesh.TlsCertificate.file({
+            certificateChainPath: 'path/to/certChain',
+            privateKeyPath: 'path/to/privateKey',
+          }),
+          validation: {
+            subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mymesh.local']),
+            trust: appmesh.TlsValidationTrust.file({
+              certificateChain: 'path/to/certChain',
+            }),
+          },
+        },
+      },
+    ),
+  ],
 });
 
 const node3 = mesh.addVirtualNode('node3', {
@@ -114,6 +130,48 @@ const node3 = mesh.addVirtualNode('node3', {
   },
   accessLog: appmesh.AccessLog.fromFilePath('/dev/stdout'),
 });
+
+const node4 = mesh.addVirtualNode('node4', {
+  serviceDiscovery: appmesh.ServiceDiscovery.dns(`node4.${namespace.namespaceName}`),
+  listeners: [appmesh.VirtualNodeListener.http({
+    tls: {
+      mode: appmesh.TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.sds({
+        secretName: 'spiffe://domain.local/backend-service',
+      }),
+      validation: {
+        trust: appmesh.TlsValidationTrust.sds({
+          secretName: 'spiffe://domain.local',
+        }),
+        subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['client.domain.local']),
+      },
+    },
+    healthCheck: appmesh.HealthCheck.http({
+      healthyThreshold: 3,
+      interval: cdk.Duration.seconds(5),
+      path: '/check-path3',
+      timeout: cdk.Duration.seconds(2),
+      unhealthyThreshold: 2,
+    }),
+  })],
+  backendDefaults: {
+    tlsClientPolicy: {
+      validation: {
+        trust: appmesh.TlsValidationTrust.file({
+          certificateChain: 'path-to-certificate',
+        }),
+      },
+    },
+  },
+  accessLog: appmesh.AccessLog.fromFilePath('/dev/stdout'),
+});
+
+node4.addBackend(appmesh.Backend.virtualService(
+  new appmesh.VirtualService(stack, 'service-4', {
+    virtualServiceName: 'service4.domain.local',
+    virtualServiceProvider: appmesh.VirtualServiceProvider.none(mesh),
+  }),
+));
 
 router.addRoute('route-2', {
   routeSpec: appmesh.RouteSpec.http({
@@ -223,6 +281,40 @@ new appmesh.VirtualGateway(stack, 'gateway2', {
       }),
     },
   })],
+});
+
+new appmesh.VirtualGateway(stack, 'gateway3', {
+  mesh: mesh,
+  listeners: [appmesh.VirtualGatewayListener.http({
+    port: 443,
+    healthCheck: appmesh.HealthCheck.http({
+      interval: cdk.Duration.seconds(10),
+    }),
+    tls: {
+      mode: appmesh.TlsMode.STRICT,
+      certificate: appmesh.TlsCertificate.sds({
+        secretName: 'secret_certificate',
+      }),
+      validation: {
+        trust: appmesh.TlsValidationTrust.file({
+          certificateChain: 'path/to/certChain',
+        }),
+      },
+    },
+  })],
+  backendDefaults: {
+    tlsClientPolicy: {
+      certificate: appmesh.TlsCertificate.file({
+        certificateChainPath: 'path/to/certChain',
+        privateKeyPath: 'path/to/privateKey',
+      }),
+      validation: {
+        trust: appmesh.TlsValidationTrust.sds({
+          secretName: 'secret_validation',
+        }),
+      },
+    },
+  },
 });
 
 gateway.addGatewayRoute('gateway1-route-http', {

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -97,7 +97,9 @@ const node2 = mesh.addVirtualNode('node2', {
             privateKeyPath: 'path/to/privateKey',
           }),
           validation: {
-            subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mymesh.local']),
+            subjectAlternativeNames: {
+              exactMatch: ['mymesh.local'],
+            },
             trust: appmesh.TlsValidationTrust.file({
               certificateChain: 'path/to/certChain',
             }),
@@ -143,7 +145,9 @@ const node4 = mesh.addVirtualNode('node4', {
         trust: appmesh.TlsValidationTrust.sds({
           secretName: 'spiffe://domain.local',
         }),
-        subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['client.domain.local']),
+        subjectAlternativeNames: {
+          exactMatch: ['client.domain.local'],
+        },
       },
     },
     healthCheck: appmesh.HealthCheck.http({

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -97,7 +97,7 @@ const node2 = mesh.addVirtualNode('node2', {
             privateKeyPath: 'path/to/privateKey',
           }),
           validation: {
-            subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mymesh.local']),
+            subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mymesh.local']),
             trust: appmesh.TlsValidationTrust.file({
               certificateChain: 'path/to/certChain',
             }),
@@ -143,7 +143,7 @@ const node4 = mesh.addVirtualNode('node4', {
         trust: appmesh.TlsValidationTrust.sds({
           secretName: 'spiffe://domain.local',
         }),
-        subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['client.domain.local']),
+        subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['client.domain.local']),
       },
     },
     healthCheck: appmesh.HealthCheck.http({

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -409,7 +409,7 @@ export = {
                 secretName: 'secret_certificate',
               }),
               validation: {
-                subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
+                subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
                 trust: appmesh.TlsValidationTrust.sds({
                   secretName: 'secret_validation',
                 }),
@@ -598,7 +598,7 @@ export = {
         backendDefaults: {
           tlsClientPolicy: {
             validation: {
-              subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
+              subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
               trust: appmesh.TlsValidationTrust.file({
                 certificateChain: 'path-to-certificate',
               }),

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -1,4 +1,5 @@
 import { expect, haveResourceLike } from '@aws-cdk/assert-internal';
+import * as acmpca from '@aws-cdk/aws-acmpca';
 import * as acm from '@aws-cdk/aws-certificatemanager';
 import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
@@ -248,6 +249,197 @@ export = {
       test.done();
     },
 
+    'with an http2 listener with a TLS certificate from SDS'(test: Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      // WHEN
+      new appmesh.VirtualGateway(stack, 'testGateway', {
+        virtualGatewayName: 'test-gateway',
+        mesh: mesh,
+        listeners: [appmesh.VirtualGatewayListener.http2({
+          port: 8080,
+          tls: {
+            mode: appmesh.TlsMode.STRICT,
+            certificate: appmesh.TlsCertificate.sds({
+              secretName: 'secret_certificate',
+            }),
+          },
+        })],
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+        Spec: {
+          Listeners: [
+            {
+              TLS: {
+                Mode: appmesh.TlsMode.STRICT,
+                Certificate: {
+                  SDS: {
+                    SecretName: 'secret_certificate',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }));
+
+      test.done();
+    },
+
+    'with an http listener with TLS validation from ACM': {
+      'should throw an error'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+        const cert = new acm.Certificate(stack, 'cert', {
+          domainName: '',
+        });
+        const certificateAuthorityArn = 'arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012';
+
+        // WHEN + THEN
+        test.throws(() => {
+          new appmesh.VirtualGateway(stack, 'testGateway', {
+            virtualGatewayName: 'test-gateway',
+            mesh: mesh,
+            listeners: [appmesh.VirtualGatewayListener.http({
+              port: 8080,
+              tls: {
+                mode: appmesh.TlsMode.STRICT,
+                certificate: appmesh.TlsCertificate.acm({
+                  certificate: cert,
+                }),
+                validation: {
+                  trust: appmesh.TlsValidationTrust.acm({
+                    certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
+                  }),
+                },
+              },
+            })],
+          });
+        }, /ACM certificate source is currently not supported/);
+
+        test.done();
+      },
+    },
+
+    'with an grpc listener with a TLS validation from file': {
+      'the listener should include the TLS configuration'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualGateway(stack, 'testGateway', {
+          virtualGatewayName: 'test-gateway',
+          mesh: mesh,
+          listeners: [appmesh.VirtualGatewayListener.grpc({
+            port: 8080,
+            tls: {
+              mode: appmesh.TlsMode.STRICT,
+              certificate: appmesh.TlsCertificate.file({
+                certificateChainPath: 'path/to/certChain',
+                privateKeyPath: 'path/to/privateKey',
+              }),
+              validation: {
+                trust: appmesh.TlsValidationTrust.file({
+                  certificateChain: 'path/to/certChain',
+                }),
+              },
+            },
+          })],
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+          Spec: {
+            Listeners: [
+              {
+                TLS: {
+                  Mode: appmesh.TlsMode.STRICT,
+                  Certificate: {
+                    File: {
+                      CertificateChain: 'path/to/certChain',
+                      PrivateKey: 'path/to/privateKey',
+                    },
+                  },
+                  Validation: {
+                    Trust: {
+                      File: {
+                        CertificateChain: 'path/to/certChain',
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }));
+
+        test.done();
+      },
+    },
+
+    'with an http2 listener with a TLS validation from SDS': {
+      'the listener should include the TLS configuration'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualGateway(stack, 'testGateway', {
+          virtualGatewayName: 'test-gateway',
+          mesh: mesh,
+          listeners: [appmesh.VirtualGatewayListener.http2({
+            port: 8080,
+            tls: {
+              mode: appmesh.TlsMode.STRICT,
+              certificate: appmesh.TlsCertificate.sds({
+                secretName: 'secret_certificate',
+              }),
+              validation: {
+                subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
+                trust: appmesh.TlsValidationTrust.sds({
+                  secretName: 'secret_validation',
+                }),
+              },
+            },
+          })],
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+          Spec: {
+            Listeners: [
+              {
+                TLS: {
+                  Mode: appmesh.TlsMode.STRICT,
+                  Certificate: {
+                    SDS: {
+                      SecretName: 'secret_certificate',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }));
+
+        test.done();
+      },
+    },
+
     'with an grpc listener with the TLS mode permissive'(test: Test) {
       // GIVEN
       const stack = new cdk.Stack();
@@ -399,6 +591,7 @@ export = {
         backendDefaults: {
           tlsClientPolicy: {
             validation: {
+              subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
               trust: appmesh.TlsValidationTrust.file({
                 certificateChain: 'path-to-certificate',
               }),
@@ -415,6 +608,11 @@ export = {
             ClientPolicy: {
               TLS: {
                 Validation: {
+                  SubjectAlternativeNames: {
+                    Match: {
+                      Exact: ['mesh-endpoint.apps.local'],
+                    },
+                  },
                   Trust: {
                     File: {
                       CertificateChain: 'path-to-certificate',
@@ -428,6 +626,94 @@ export = {
       }));
 
       test.done();
+    },
+
+    'with client\'s TLS certificate from SDS': {
+      'should add a backend default to the resource with TLS certificate'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualGateway(stack, 'virtual-gateway', {
+          virtualGatewayName: 'virtual-gateway',
+          mesh: mesh,
+          backendDefaults: {
+            tlsClientPolicy: {
+              certificate: appmesh.TlsCertificate.sds( {
+                secretName: 'secret_certificate',
+              }),
+              validation: {
+                trust: appmesh.TlsValidationTrust.sds({
+                  secretName: 'secret_validation',
+                }),
+              },
+            },
+          },
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+          VirtualGatewayName: 'virtual-gateway',
+          Spec: {
+            BackendDefaults: {
+              ClientPolicy: {
+                TLS: {
+                  Certificate: {
+                    SDS: {
+                      SecretName: 'secret_certificate',
+                    },
+                  },
+                  Validation: {
+                    Trust: {
+                      SDS: {
+                        SecretName: 'secret_validation',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }));
+
+        test.done();
+      },
+    },
+
+    'with client\'s TLS certificate from ACM': {
+      'should throw an error if TLS certificate from ACM is selected as a source'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+        const cert = new acm.Certificate(stack, 'cert', {
+          domainName: '',
+        });
+
+        // WHEN + Then
+        test.throws(() => new appmesh.VirtualGateway(stack, 'virtual-gateway', {
+          virtualGatewayName: 'virtual-gateway',
+          mesh: mesh,
+          backendDefaults: {
+            tlsClientPolicy: {
+              certificate: appmesh.TlsCertificate.acm({
+                certificate: cert,
+              }),
+              validation: {
+                trust: appmesh.TlsValidationTrust.file({
+                  certificateChain: 'path-to-certificate',
+                }),
+              },
+            },
+          },
+        }), /ACM certificate source is currently not supported/);
+
+        test.done();
+      },
     },
   },
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -430,6 +430,13 @@ export = {
                       SecretName: 'secret_certificate',
                     },
                   },
+                  Validation: {
+                    SubjectAlternativeNames: {
+                      Match: {
+                        Exact: ['mesh-endpoint.apps.local'],
+                      },
+                    },
+                  },
                 },
               },
             ],

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -409,7 +409,9 @@ export = {
                 secretName: 'secret_certificate',
               }),
               validation: {
-                subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
+                subjectAlternativeNames: {
+                  exactMatch: ['mesh-endpoint.apps.local'],
+                },
                 trust: appmesh.TlsValidationTrust.sds({
                   secretName: 'secret_validation',
                 }),
@@ -598,7 +600,9 @@ export = {
         backendDefaults: {
           tlsClientPolicy: {
             validation: {
-              subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
+              subjectAlternativeNames: {
+                exactMatch: ['mesh-endpoint.apps.local'],
+              },
               trust: appmesh.TlsValidationTrust.file({
                 certificateChain: 'path-to-certificate',
               }),

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -261,7 +261,7 @@ export = {
     },
 
     'when a listener is added with outlier detection with user defined props': {
-      'should add a listener  outlier detection to the resource'(test: Test) {
+      'should add a listener outlier detection to the resource'(test: Test) {
         // GIVEN
         const stack = new cdk.Stack();
 
@@ -334,6 +334,7 @@ export = {
             tlsClientPolicy: {
               ports: [8080, 8081],
               validation: {
+                subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
                 trust: appmesh.TlsValidationTrust.acm({
                   certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
                 }),
@@ -350,6 +351,11 @@ export = {
                 TLS: {
                   Ports: [8080, 8081],
                   Validation: {
+                    SubjectAlternativeNames: {
+                      Match: {
+                        Exact: ['mesh-endpoint.apps.local'],
+                      },
+                    },
                     Trust: {
                       ACM: {
                         CertificateAuthorityArns: [`${certificateAuthorityArn}`],
@@ -363,6 +369,99 @@ export = {
         }));
 
         test.done();
+      },
+
+      'with client\'s TLS certificate from SDS': {
+        'should add a backend default to the resource with TLS certificate'(test: Test) {
+          // GIVEN
+          const stack = new cdk.Stack();
+          const mesh = new appmesh.Mesh(stack, 'mesh', {
+            meshName: 'test-mesh',
+          });
+
+          // WHEN
+          new appmesh.VirtualNode(stack, 'test-node', {
+            mesh,
+            serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
+            backendDefaults: {
+              tlsClientPolicy: {
+                certificate: appmesh.TlsCertificate.sds( {
+                  secretName: 'secret_certificate',
+                }),
+                ports: [8080, 8081],
+                validation: {
+                  trust: appmesh.TlsValidationTrust.sds({
+                    secretName: 'secret_validation',
+                  }),
+                },
+              },
+            },
+          });
+
+          // THEN
+          expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+            Spec: {
+              BackendDefaults: {
+                ClientPolicy: {
+                  TLS: {
+                    Certificate: {
+                      SDS: {
+                        SecretName: 'secret_certificate',
+                      },
+                    },
+                    Ports: [8080, 8081],
+                    Validation: {
+                      Trust: {
+                        SDS: {
+                          SecretName: 'secret_validation',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }));
+
+          test.done();
+        },
+      },
+
+      'with client\'s TLS certificate from ACM': {
+        'should throw an error'(test: Test) {
+          // GIVEN
+          const stack = new cdk.Stack();
+          const mesh = new appmesh.Mesh(stack, 'mesh', {
+            meshName: 'test-mesh',
+          });
+          const certificateAuthorityArn = 'arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012';
+          const cert = new acm.Certificate(stack, 'cert', {
+            domainName: '',
+          });
+
+          // WHEN + THEN
+          test.throws(() => {
+            new appmesh.VirtualNode(stack, 'test-node', {
+              mesh,
+              serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
+              backendDefaults: {
+                tlsClientPolicy: {
+                  certificate: appmesh.TlsCertificate.acm({
+                    certificate: cert,
+                  }),
+                  ports: [8080, 8081],
+                  validation: {
+                    trust: appmesh.TlsValidationTrust.acm({
+                      certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
+                    }),
+                  },
+                },
+              },
+            });
+          }, /ACM certificate source is currently not supported./);
+
+          test.done();
+        },
       },
     },
 
@@ -388,6 +487,9 @@ export = {
 
         node.addBackend(appmesh.Backend.virtualService(service1, {
           tlsClientPolicy: {
+            certificate: appmesh.TlsCertificate.sds({
+              secretName: 'secret_certificate',
+            }),
             ports: [8080, 8081],
             validation: {
               trust: appmesh.TlsValidationTrust.file({
@@ -408,6 +510,11 @@ export = {
                   },
                   ClientPolicy: {
                     TLS: {
+                      Certificate: {
+                        SDS: {
+                          SecretName: 'secret_certificate',
+                        },
+                      },
                       Ports: [8080, 8081],
                       Validation: {
                         Trust: {
@@ -527,6 +634,50 @@ export = {
       },
     },
 
+    'when an http2 listener is added with a TLS certificate from SDS': {
+      'the listener should include the TLS configuration'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualNode(stack, 'test-node', {
+          mesh,
+          listeners: [appmesh.VirtualNodeListener.http2({
+            port: 80,
+            tls: {
+              mode: appmesh.TlsMode.STRICT,
+              certificate: appmesh.TlsCertificate.sds({
+                secretName: 'secret_certificate',
+              }),
+            },
+          })],
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+          Spec: {
+            Listeners: [
+              {
+                TLS: {
+                  Mode: appmesh.TlsMode.STRICT,
+                  Certificate: {
+                    SDS: {
+                      SecretName: 'secret_certificate',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }));
+
+        test.done();
+      },
+    },
+
     'when an http listener is added with the TLS mode permissive': {
       'the listener should include the TLS configuration'(test: Test) {
         // GIVEN
@@ -569,6 +720,99 @@ export = {
             ],
           },
         }));
+
+        test.done();
+      },
+    },
+
+    'when an http listener is added with the TLS Validation from SDS': {
+      'the listener should include the TLS configuration'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualNode(stack, 'test-node', {
+          mesh,
+          listeners: [appmesh.VirtualNodeListener.http({
+            port: 80,
+            tls: {
+              mode: appmesh.TlsMode.PERMISSIVE,
+              certificate: appmesh.TlsCertificate.file({
+                certificateChainPath: 'path/to/certChain',
+                privateKeyPath: 'path/to/privateKey',
+              }),
+              validation: {
+                trust: appmesh.TlsValidationTrust.sds({
+                  secretName: 'secret',
+                }),
+              },
+            },
+          })],
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+          Spec: {
+            Listeners: [
+              {
+                TLS: {
+                  Mode: appmesh.TlsMode.PERMISSIVE,
+                  Certificate: {
+                    File: {
+                      CertificateChain: 'path/to/certChain',
+                      PrivateKey: 'path/to/privateKey',
+                    },
+                  },
+                  Validation: {
+                    Trust: {
+                      SDS: {
+                        SecretName: 'secret',
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        }));
+
+        test.done();
+      },
+    },
+
+    'when an http listener is added with the TLS Validation from ACM': {
+      'should throw an error'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+        const certificateAuthorityArn = 'arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012';
+
+        // WHEN + THEN
+        test.throws(() => {
+          new appmesh.VirtualNode(stack, 'test-node', {
+            mesh,
+            listeners: [appmesh.VirtualNodeListener.http({
+              port: 80,
+              tls: {
+                mode: appmesh.TlsMode.PERMISSIVE,
+                certificate: appmesh.TlsCertificate.file({
+                  certificateChainPath: 'path/to/certChain',
+                  privateKeyPath: 'path/to/privateKey',
+                }),
+                validation: {
+                  trust: appmesh.TlsValidationTrust.acm({
+                    certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
+                  }),
+                },
+              },
+            })],
+          });
+        }, /ACM certificate source is currently not supported/),
 
         test.done();
       },

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -334,7 +334,7 @@ export = {
             tlsClientPolicy: {
               ports: [8080, 8081],
               validation: {
-                subjectAlternativeNames: appmesh.SubjectiveAlternativeNamesMatch.valuesAre(['mesh-endpoint.apps.local']),
+                subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
                 trust: appmesh.TlsValidationTrust.acm({
                   certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
                 }),

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -334,7 +334,9 @@ export = {
             tlsClientPolicy: {
               ports: [8080, 8081],
               validation: {
-                subjectAlternativeNames: appmesh.SubjectiveAlternativeNames.exactMatch(['mesh-endpoint.apps.local']),
+                subjectAlternativeNames: {
+                  exactMatch: ['mesh-endpoint.apps.local'],
+                },
                 trust: appmesh.TlsValidationTrust.acm({
                   certificateAuthorities: [acmpca.CertificateAuthority.fromCertificateAuthorityArn(stack, 'certificate', certificateAuthorityArn)],
                 }),


### PR DESCRIPTION
**Note:**  
- this is for internal-review purpose only. I will submit the PR to main repo once I receive green from the team.
- This review **DOES NOT** include changes on `README` file yet. `README` file needs to be updated to include mTLS implementation example.

----
This is the last part of the series to implement mTLS feature and #12733.
For the breakdown on series, please refer to
[this comment](https://github.com/aws/aws-cdk/pull/14782#discussion_r636334863).

#### Collaborators
@alexbrjo and @dfezzie. Thank you!

#### REV
 - Adding SDS certificate source to `TlsCertificate` and `TlsValidationTrust`.
 - Adding `subjectAlternativeNames` property to `TlsValidation`.
 - Adding `certificate` property to `TlsClientPolicy`
 - Adding `validation` property to `TlsListener`

#### Design Note:
 - Client certificates in a TLS Client Policy and server validation in a listener TLS configuration can only be sourced from `SDS` or `File` certificate. ACM certificate is currently not supported ([ref](https://docs.aws.amazon.com/app-mesh/latest/userguide/mutual-tls.html))
   - when ACM certificate is selected, run-time error is thrown.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
