### PR TITLE
feat(appmesh): add mesh owner property

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -678,6 +678,7 @@ gateway.grantStreamAggregatedResources(envoyUser)
 ## Adding Resources to shared meshes
 
 A shared mesh allows resources created by different accounts to communicate with each other in the same mesh.
+For more information about mesh sharing, see [Working with shared meshes](https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html).
 
 ```ts
 // This is the ARN for the mesh from different AWS IAM account ID.

--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -674,3 +674,20 @@ const envoyUser = new iam.User(stack, 'envoyUser');
  */
 gateway.grantStreamAggregatedResources(envoyUser)
 ``` 
+
+## Adding Resources to shared meshes
+
+A shared mesh allows resources created by different accounts to communicate with each other in the same mesh.
+
+```ts
+// This is the ARN for the mesh from different AWS IAM account ID.
+// Ensure mesh is properly shared with your account
+const arn = 'arn:aws:appmesh:us-east-1:123456789012:mesh/testMesh';
+appmesh.Mesh.fromMeshArn(stack, 'imported-mesh', arn);
+
+// This VirtualNode resource can communicate with the resources in the mesh from different AWS IAM account ID.
+new appmesh.VirtualNode(stack, 'test-node', {
+  mesh: sharedMesh,
+});
+```
+

--- a/packages/@aws-cdk/aws-appmesh/lib/gateway-route.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/gateway-route.ts
@@ -113,7 +113,7 @@ export class GatewayRoute extends cdk.Resource implements IGatewayRoute {
     const gatewayRoute = new CfnGatewayRoute(this, 'Resource', {
       gatewayRouteName: this.physicalName,
       meshName: props.virtualGateway.mesh.meshName,
-      meshOwner: props.virtualGateway.mesh.env.account,
+      meshOwner: props.virtualGateway.mesh.meshOwner,
       spec: {
         httpRoute: routeSpecConfig.httpSpecConfig,
         http2Route: routeSpecConfig.http2SpecConfig,

--- a/packages/@aws-cdk/aws-appmesh/lib/gateway-route.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/gateway-route.ts
@@ -113,6 +113,7 @@ export class GatewayRoute extends cdk.Resource implements IGatewayRoute {
     const gatewayRoute = new CfnGatewayRoute(this, 'Resource', {
       gatewayRouteName: this.physicalName,
       meshName: props.virtualGateway.mesh.meshName,
+      meshOwner: props.virtualGateway.mesh.env.account,
       spec: {
         httpRoute: routeSpecConfig.httpSpecConfig,
         http2Route: routeSpecConfig.http2SpecConfig,

--- a/packages/@aws-cdk/aws-appmesh/lib/mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/mesh.ts
@@ -43,6 +43,8 @@ export interface IMesh extends cdk.IResource {
   /**
    * The AWS IAM account ID of the AppMesh mesh
    *
+   * @see https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html
+   *
    * @attribute
    */
   readonly meshOwner: string;

--- a/packages/@aws-cdk/aws-appmesh/lib/mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/mesh.ts
@@ -41,6 +41,13 @@ export interface IMesh extends cdk.IResource {
   readonly meshArn: string;
 
   /**
+   * The AWS IAM account ID of the AppMesh mesh
+   *
+   * @attribute
+   */
+  readonly meshOwner: string;
+
+  /**
    * Creates a new VirtualRouter in this Mesh.
    * Note that the Router is created in the same Stack that this Mesh belongs to,
    * which might be different than the current stack.
@@ -75,6 +82,11 @@ abstract class MeshBase extends cdk.Resource implements IMesh {
    * The Amazon Resource Name (ARN) of the AppMesh mesh
    */
   public abstract readonly meshArn: string;
+
+  /**
+   * The AWS IAM account ID of the AppMesh mesh
+   */
+  public abstract readonly meshOwner: string;
 
   /**
    * Adds a VirtualRouter to the Mesh with the given id and props
@@ -141,6 +153,7 @@ export class Mesh extends MeshBase {
     class Import extends MeshBase {
       public meshName = parts.resourceName || '';
       public meshArn = meshArn;
+      public meshOwner = parts.account || '';
     }
 
     return new Import(scope, id);
@@ -159,6 +172,7 @@ export class Mesh extends MeshBase {
     class Import extends MeshBase {
       public meshName = meshName;
       public meshArn = arn;
+      public meshOwner = this.env.account;
     }
 
     return new Import(scope, id);
@@ -173,6 +187,11 @@ export class Mesh extends MeshBase {
    * The Amazon Resource Name (ARN) of the AppMesh mesh
    */
   public readonly meshArn: string;
+
+  /**
+   * The AWS IAM account ID of the AppMesh mesh
+   */
+  public readonly meshOwner: string;
 
   constructor(scope: Construct, id: string, props: MeshProps = {}) {
     super(scope, id, {
@@ -194,5 +213,6 @@ export class Mesh extends MeshBase {
       resource: 'mesh',
       resourceName: this.physicalName,
     });
+    this.meshOwner = this.env.account;
   }
 }

--- a/packages/@aws-cdk/aws-appmesh/lib/route.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/route.ts
@@ -120,6 +120,7 @@ export class Route extends cdk.Resource implements IRoute {
     const route = new CfnRoute(this, 'Resource', {
       routeName: this.physicalName,
       meshName: this.virtualRouter.mesh.meshName,
+      meshOwner: this.virtualRouter.mesh.env.account,
       virtualRouterName: this.virtualRouter.virtualRouterName,
       spec: {
         tcpRoute: spec.tcpRouteSpec,

--- a/packages/@aws-cdk/aws-appmesh/lib/route.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/route.ts
@@ -120,7 +120,7 @@ export class Route extends cdk.Resource implements IRoute {
     const route = new CfnRoute(this, 'Resource', {
       routeName: this.physicalName,
       meshName: this.virtualRouter.mesh.meshName,
-      meshOwner: this.virtualRouter.mesh.env.account,
+      meshOwner: this.virtualRouter.mesh.meshOwner,
       virtualRouterName: this.virtualRouter.virtualRouterName,
       spec: {
         tcpRoute: spec.tcpRouteSpec,

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
@@ -192,6 +192,7 @@ export class VirtualGateway extends VirtualGatewayBase {
     const node = new CfnVirtualGateway(this, 'Resource', {
       virtualGatewayName: this.physicalName,
       meshName: this.mesh.meshName,
+      meshOwner: this.mesh.env.account,
       spec: {
         listeners: this.listeners.map(listener => listener.listener),
         backendDefaults: props.backendDefaults !== undefined

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-gateway.ts
@@ -192,7 +192,7 @@ export class VirtualGateway extends VirtualGatewayBase {
     const node = new CfnVirtualGateway(this, 'Resource', {
       virtualGatewayName: this.physicalName,
       meshName: this.mesh.meshName,
-      meshOwner: this.mesh.env.account,
+      meshOwner: this.mesh.meshOwner,
       spec: {
         listeners: this.listeners.map(listener => listener.listener),
         backendDefaults: props.backendDefaults !== undefined

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
@@ -194,6 +194,7 @@ export class VirtualNode extends VirtualNodeBase {
     const node = new CfnVirtualNode(this, 'Resource', {
       virtualNodeName: this.physicalName,
       meshName: this.mesh.meshName,
+      meshOwner: props.mesh.env.account,
       spec: {
         backends: cdk.Lazy.any({ produce: () => this.backends }, { omitEmptyArray: true }),
         listeners: cdk.Lazy.any({ produce: () => this.listeners.map(listener => listener.listener) }, { omitEmptyArray: true }),

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
@@ -194,7 +194,7 @@ export class VirtualNode extends VirtualNodeBase {
     const node = new CfnVirtualNode(this, 'Resource', {
       virtualNodeName: this.physicalName,
       meshName: this.mesh.meshName,
-      meshOwner: props.mesh.env.account,
+      meshOwner: props.mesh.meshOwner,
       spec: {
         backends: cdk.Lazy.any({ produce: () => this.backends }, { omitEmptyArray: true }),
         listeners: cdk.Lazy.any({ produce: () => this.listeners.map(listener => listener.listener) }, { omitEmptyArray: true }),

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-router.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-router.ts
@@ -154,7 +154,7 @@ export class VirtualRouter extends VirtualRouterBase {
     const router = new CfnVirtualRouter(this, 'Resource', {
       virtualRouterName: this.physicalName,
       meshName: this.mesh.meshName,
-      meshOwner: this.mesh.env.account,
+      meshOwner: this.mesh.meshOwner,
       spec: {
         listeners: this.listeners,
       },

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-router.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-router.ts
@@ -154,6 +154,7 @@ export class VirtualRouter extends VirtualRouterBase {
     const router = new CfnVirtualRouter(this, 'Resource', {
       virtualRouterName: this.physicalName,
       meshName: this.mesh.meshName,
+      meshOwner: this.mesh.env.account,
       spec: {
         listeners: this.listeners,
       },

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-service.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-service.ts
@@ -110,6 +110,7 @@ export class VirtualService extends cdk.Resource implements IVirtualService {
 
     const svc = new CfnVirtualService(this, 'Resource', {
       meshName: this.mesh.meshName,
+      meshOwner: this.mesh.env.account,
       virtualServiceName: this.physicalName,
       spec: {
         provider: providerConfig.virtualNodeProvider || providerConfig.virtualRouterProvider

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-service.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-service.ts
@@ -110,7 +110,7 @@ export class VirtualService extends cdk.Resource implements IVirtualService {
 
     const svc = new CfnVirtualService(this, 'Resource', {
       meshName: this.mesh.meshName,
-      meshOwner: this.mesh.env.account,
+      meshOwner: this.mesh.meshOwner,
       virtualServiceName: this.physicalName,
       spec: {
         provider: providerConfig.virtualNodeProvider || providerConfig.virtualRouterProvider

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -95,14 +95,14 @@
     "vpcPublicSubnet1NATGateway9C16659E": {
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
+        "SubnetId": {
+          "Ref": "vpcPublicSubnet1Subnet2E65531E"
+        },
         "AllocationId": {
           "Fn::GetAtt": [
             "vpcPublicSubnet1EIPDA49DCBE",
             "AllocationId"
           ]
-        },
-        "SubnetId": {
-          "Ref": "vpcPublicSubnet1Subnet2E65531E"
         },
         "Tags": [
           {
@@ -485,6 +485,9 @@
             }
           ]
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "VirtualRouterName": "meshstackmeshrouter2FE6E358"
       }
     },
@@ -532,6 +535,9 @@
             "meshrouter81B8087E",
             "VirtualRouterName"
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "RouteName": "route-1"
       }
@@ -581,6 +587,9 @@
             "VirtualRouterName"
           ]
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "RouteName": "route-2"
       }
     },
@@ -621,6 +630,9 @@
             "meshrouter81B8087E",
             "VirtualRouterName"
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "RouteName": "route-3"
       }
@@ -665,6 +677,9 @@
             "meshrouter81B8087E",
             "VirtualRouterName"
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "RouteName": "route-4"
       }
@@ -784,6 +799,9 @@
             "VirtualRouterName"
           ]
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "RouteName": "route-matching"
       }
     },
@@ -835,6 +853,9 @@
             "VirtualRouterName"
           ]
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "RouteName": "route-http2-retry"
       }
     },
@@ -873,6 +894,9 @@
             "meshrouter81B8087E",
             "VirtualRouterName"
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "RouteName": "route-5"
       }
@@ -927,6 +951,9 @@
             "meshrouter81B8087E",
             "VirtualRouterName"
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "RouteName": "route-grpc-retry"
       }
@@ -985,6 +1012,9 @@
               "Hostname": "node1.domain.local"
             }
           }
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "VirtualNodeName": "meshstackmeshnode61AD3D23"
       }
@@ -1047,6 +1077,9 @@
             }
           }
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "VirtualNodeName": "meshstackmeshnode2F1F28441"
       }
     },
@@ -1102,6 +1135,9 @@
               "Hostname": "node3.domain.local"
             }
           }
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "VirtualNodeName": "meshstackmeshnode3C5835BCB"
       }
@@ -1206,6 +1242,9 @@
             }
           }
         },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        },
         "VirtualNodeName": "meshstackmeshnode404B014E7"
       }
     },
@@ -1234,6 +1273,9 @@
               }
             }
           }
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "VirtualGatewayName": "gateway1"
       }
@@ -1272,7 +1314,10 @@
             "VirtualGatewayName"
           ]
         },
-        "GatewayRouteName": "meshstackmeshgateway1gateway1routehttpBA921D42"
+        "GatewayRouteName": "meshstackmeshgateway1gateway1routehttpBA921D42",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "meshgateway1gateway1routehttp2FD69C306": {
@@ -1309,7 +1354,10 @@
             "VirtualGatewayName"
           ]
         },
-        "GatewayRouteName": "meshstackmeshgateway1gateway1routehttp255781963"
+        "GatewayRouteName": "meshstackmeshgateway1gateway1routehttp255781963",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "meshgateway1gateway1routegrpc76486062": {
@@ -1351,7 +1399,10 @@
             "VirtualGatewayName"
           ]
         },
-        "GatewayRouteName": "meshstackmeshgateway1gateway1routegrpcCD4D891D"
+        "GatewayRouteName": "meshstackmeshgateway1gateway1routegrpcCD4D891D",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "service6D174F83": {
@@ -1375,7 +1426,10 @@
             }
           }
         },
-        "VirtualServiceName": "service1.domain.local"
+        "VirtualServiceName": "service1.domain.local",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "service27C65CF7D": {
@@ -1388,7 +1442,10 @@
           ]
         },
         "Spec": {},
-        "VirtualServiceName": "service2.domain.local"
+        "VirtualServiceName": "service2.domain.local",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "service3859EB104": {
@@ -1401,7 +1458,10 @@
           ]
         },
         "Spec": {},
-        "VirtualServiceName": "service3.domain.local"
+        "VirtualServiceName": "service3.domain.local",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "service4983B61EE": {
@@ -1414,7 +1474,10 @@
           ]
         },
         "Spec": {},
-        "VirtualServiceName": "service4.domain.local"
+        "VirtualServiceName": "service4.domain.local",
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
+        }
       }
     },
     "gateway2BCE5C5E0": {
@@ -1453,6 +1516,9 @@
               }
             }
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "VirtualGatewayName": "meshstackgateway2BEC62D7C"
       }
@@ -1517,6 +1583,9 @@
               }
             }
           ]
+        },
+        "MeshOwner": {
+          "Ref": "AWS::AccountId"
         },
         "VirtualGatewayName": "meshstackgateway34EC5ED00"
       }

--- a/packages/@aws-cdk/aws-appmesh/test/test.gateway-route.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.gateway-route.ts
@@ -134,37 +134,37 @@ export = {
       test.done();
     },
 
-    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
-      // GIVEN
-      const stack = new cdk.Stack();
-      const mesh = new appmesh.Mesh(stack, 'mesh', {
-        meshName: 'test-mesh',
-      });
-      const virtualGateway = new appmesh.VirtualGateway(stack, 'gateway-1', {
-        listeners: [appmesh.VirtualGatewayListener.http()],
-        mesh: mesh,
-      });
-      const virtualService = new appmesh.VirtualService(stack, 'vs-1', {
-        virtualServiceProvider: appmesh.VirtualServiceProvider.none(mesh),
-        virtualServiceName: 'target.local',
-      });
+    'with shared service mesh': {
+      'Mesh Owner is the AWS account ID of the account that shared the mesh with your account'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const accountId = '123456789012';
+        const sharedMesh = appmesh.Mesh
+          .fromMeshArn(stack, 'shared-mesh', `arn:aws:appmesh:us-west-2:${accountId}:mesh/shared-mesh`);
+        const virtualGateway = new appmesh.VirtualGateway(stack, 'gateway-1', {
+          listeners: [appmesh.VirtualGatewayListener.http()],
+          mesh: sharedMesh,
+        });
+        const virtualService = new appmesh.VirtualService(stack, 'vs-1', {
+          virtualServiceProvider: appmesh.VirtualServiceProvider.none(sharedMesh),
+          virtualServiceName: 'target.local',
+        });
 
-      // WHEN
-      new appmesh.GatewayRoute(stack, 'test-node', {
-        routeSpec: appmesh.GatewayRouteSpec.http({
-          routeTarget: virtualService,
-        }),
-        virtualGateway: virtualGateway,
-      });
+        // WHEN
+        new appmesh.GatewayRoute(stack, 'test-node', {
+          routeSpec: appmesh.GatewayRouteSpec.http({
+            routeTarget: virtualService,
+          }),
+          virtualGateway: virtualGateway,
+        });
 
-      // THEN
-      expect(stack).to(haveResourceLike('AWS::AppMesh::GatewayRoute', {
-        MeshOwner: {
-          Ref: 'AWS::AccountId',
-        },
-      }));
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::GatewayRoute', {
+          MeshOwner: accountId,
+        }));
 
-      test.done();
+        test.done();
+      },
     },
   },
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.route.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.route.ts
@@ -575,45 +575,45 @@ export = {
       test.done();
     },
 
-    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test: Test) {
-      // GIVEN
-      const stack = new cdk.Stack();
-      const mesh = new appmesh.Mesh(stack, 'mesh', {
-        meshName: 'test-mesh',
-      });
-      const router = new appmesh.VirtualRouter(stack, 'router', {
-        mesh,
-      });
-      const virtualNode = mesh.addVirtualNode('test-node', {
-        serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
-        listeners: [appmesh.VirtualNodeListener.http()],
-      });
+    'with shared service mesh': {
+      'Mesh Owner is the AWS account ID of the account that shared the mesh with your account'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const accountId = '123456789012';
+        const sharedMesh = appmesh.Mesh
+          .fromMeshArn(stack, 'shared-mesh', `arn:aws:appmesh:us-west-2:${accountId}:mesh/shared-mesh`);
+        const router = new appmesh.VirtualRouter(stack, 'router', {
+          mesh: sharedMesh,
+        });
+        const virtualNode = sharedMesh.addVirtualNode('test-node', {
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
+          listeners: [appmesh.VirtualNodeListener.http()],
+        });
 
-      new appmesh.Route(stack, 'test-route', {
-        mesh: mesh,
-        routeSpec: appmesh.RouteSpec.grpc({
-          weightedTargets: [{ virtualNode }],
-          match: { serviceName: 'example' },
-          retryPolicy: {
-            grpcRetryEvents: [],
-            httpRetryEvents: [],
-            tcpRetryEvents: [appmesh.TcpRetryEvent.CONNECTION_ERROR],
-            retryAttempts: 5,
-            retryTimeout: cdk.Duration.seconds(10),
-          },
-        }),
-        virtualRouter: router,
+        new appmesh.Route(stack, 'test-route', {
+          mesh: sharedMesh,
+          routeSpec: appmesh.RouteSpec.grpc({
+            weightedTargets: [{ virtualNode }],
+            match: { serviceName: 'example' },
+            retryPolicy: {
+              grpcRetryEvents: [],
+              httpRetryEvents: [],
+              tcpRetryEvents: [appmesh.TcpRetryEvent.CONNECTION_ERROR],
+              retryAttempts: 5,
+              retryTimeout: cdk.Duration.seconds(10),
+            },
+          }),
+          virtualRouter: router,
 
-      });
+        });
 
-      // THEN
-      expect(stack).to(haveResourceLike('AWS::AppMesh::Route', {
-        MeshOwner: {
-          Ref: 'AWS::AccountId',
-        },
-      }));
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::Route', {
+          MeshOwner: accountId,
+        }));
 
-      test.done();
+        test.done();
+      },
     },
   },
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -435,26 +435,26 @@ export = {
       test.done();
     },
 
-    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
-      // GIVEN
-      const stack = new cdk.Stack();
-      const mesh = new appmesh.Mesh(stack, 'mesh', {
-        meshName: 'test-mesh',
-      });
+    'with shared service mesh': {
+      'Mesh Owner is the AWS account ID of the account that shared the mesh with your account'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const accountId = '123456789012';
+        const sharedMesh = appmesh.Mesh
+          .fromMeshArn(stack, 'shared-mesh', `arn:aws:appmesh:us-west-2:${accountId}:mesh/shared-mesh`);
 
-      // WHEN
-      new appmesh.VirtualGateway(stack, 'test-node', {
-        mesh: mesh,
-      });
+        // WHEN
+        new appmesh.VirtualGateway(stack, 'test-node', {
+          mesh: sharedMesh,
+        });
 
-      // THEN
-      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
-        MeshOwner: {
-          Ref: 'AWS::AccountId',
-        },
-      }));
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+          MeshOwner: accountId,
+        }));
 
-      test.done();
+        test.done();
+      },
     },
   },
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-gateway.ts
@@ -434,6 +434,28 @@ export = {
 
       test.done();
     },
+
+    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      // WHEN
+      new appmesh.VirtualGateway(stack, 'test-node', {
+        mesh: mesh,
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualGateway', {
+        MeshOwner: {
+          Ref: 'AWS::AccountId',
+        },
+      }));
+
+      test.done();
+    },
   },
 
   'When adding a gateway route to existing VirtualGateway ': {

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -894,4 +894,30 @@ export = {
 
     test.done();
   },
+
+  'When creating a VirtualNode': {
+    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      // WHEN
+      new appmesh.VirtualNode(stack, 'test-node', {
+        mesh: mesh,
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+        MeshOwner: {
+          Ref: 'AWS::AccountId',
+        },
+      }));
+
+      test.done();
+    },
+  },
 };
+
+

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -896,26 +896,26 @@ export = {
   },
 
   'When creating a VirtualNode': {
-    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
-      // GIVEN
-      const stack = new cdk.Stack();
-      const mesh = new appmesh.Mesh(stack, 'mesh', {
-        meshName: 'test-mesh',
-      });
+    'with shared service mesh': {
+      'Mesh Owner is the AWS account ID of the account that shared the mesh with your account'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const accountId = '123456789012';
+        const sharedMesh = appmesh.Mesh
+          .fromMeshArn(stack, 'shared-mesh', `arn:aws:appmesh:us-west-2:${accountId}:mesh/shared-mesh`);
 
-      // WHEN
-      new appmesh.VirtualNode(stack, 'test-node', {
-        mesh: mesh,
-      });
+        // WHEN
+        new appmesh.VirtualNode(stack, 'test-node', {
+          mesh: sharedMesh,
+        });
 
-      // THEN
-      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
-        MeshOwner: {
-          Ref: 'AWS::AccountId',
-        },
-      }));
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+          MeshOwner: accountId,
+        }));
 
-      test.done();
+        test.done();
+      },
     },
   },
 };

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
@@ -86,26 +86,26 @@ export = {
       test.done();
     },
 
-    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
-      // GIVEN
-      const stack = new cdk.Stack();
-      const mesh = new appmesh.Mesh(stack, 'mesh', {
-        meshName: 'test-mesh',
-      });
+    'with shared service mesh': {
+      'Mesh Owner is the AWS account ID of the account that shared the mesh with your account'(test:Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+        const accountId = '123456789012';
+        const sharedMesh = appmesh.Mesh
+          .fromMeshArn(stack, 'shared-mesh', `arn:aws:appmesh:us-west-2:${accountId}:mesh/shared-mesh`);
 
-      // WHEN
-      new appmesh.VirtualRouter(stack, 'test-node', {
-        mesh: mesh,
-      });
+        // WHEN
+        new appmesh.VirtualRouter(stack, 'test-node', {
+          mesh: sharedMesh,
+        });
 
-      // THEN
-      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualRouter', {
-        MeshOwner: {
-          Ref: 'AWS::AccountId',
-        },
-      }));
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualRouter', {
+          MeshOwner: accountId,
+        }));
 
-      test.done();
+        test.done();
+      },
     },
   },
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
@@ -85,6 +85,28 @@ export = {
 
       test.done();
     },
+
+    'Mesh Owner is the AWS account ID of the account in which the stack is being created'(test:Test) {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const mesh = new appmesh.Mesh(stack, 'mesh', {
+        meshName: 'test-mesh',
+      });
+
+      // WHEN
+      new appmesh.VirtualRouter(stack, 'test-node', {
+        mesh: mesh,
+      });
+
+      // THEN
+      expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualRouter', {
+        MeshOwner: {
+          Ref: 'AWS::AccountId',
+        },
+      }));
+
+      test.done();
+    },
   },
 
   'When adding route to existing VirtualRouter': {


### PR DESCRIPTION
**This PR is for internal-review purpose only**

#### REV:
- Adding `meshOwner` attribute to `IMesh`.
- Adding `meshOwner` property for resources

#### Design Note:
- Allowing to provide Mesh ARN from different AWS IAM account ID for `IMesh.fromMeshArn()` to enable working with shared mesh.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
