### PR TITLE
feat(appmesh): Adding ResponseType and validation check

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node.ts
@@ -191,6 +191,10 @@ export class VirtualNode extends VirtualNodeBase {
     const accessLogging = props.accessLog?.bind(this);
     const serviceDiscovery = props.serviceDiscovery?.bind(this);
 
+    if ((props.listeners && props.listeners.length > 0) && !serviceDiscovery) {
+      throw new Error('If you specify a listener, then you must specify service discovery information.');
+    };
+
     const node = new CfnVirtualNode(this, 'Resource', {
       virtualNodeName: this.physicalName,
       meshName: this.mesh.meshName,

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -95,14 +95,14 @@
     "vpcPublicSubnet1NATGateway9C16659E": {
       "Type": "AWS::EC2::NatGateway",
       "Properties": {
+        "SubnetId": {
+          "Ref": "vpcPublicSubnet1Subnet2E65531E"
+        },
         "AllocationId": {
           "Fn::GetAtt": [
             "vpcPublicSubnet1EIPDA49DCBE",
             "AllocationId"
           ]
-        },
-        "SubnetId": {
-          "Ref": "vpcPublicSubnet1Subnet2E65531E"
         },
         "Tags": [
           {
@@ -1202,7 +1202,8 @@
           },
           "ServiceDiscovery": {
             "DNS": {
-              "Hostname": "node4.domain.local"
+              "Hostname": "node4.domain.local",
+              "ResponseType": "ENDPOINTS"
             }
           }
         },

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -112,7 +112,7 @@ const node3 = mesh.addVirtualNode('node3', {
 });
 
 const node4 = mesh.addVirtualNode('node4', {
-  serviceDiscovery: appmesh.ServiceDiscovery.dns(`node4.${namespace.namespaceName}`),
+  serviceDiscovery: appmesh.ServiceDiscovery.dns(`node4.${namespace.namespaceName}`, appmesh.ResponseType.ENDPOINTS),
   listeners: [appmesh.VirtualNodeListener.http({
     tls: {
       mode: appmesh.TlsMode.STRICT,

--- a/packages/@aws-cdk/aws-appmesh/test/test.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.mesh.ts
@@ -105,9 +105,7 @@ export = {
     // WHEN
     new appmesh.VirtualNode(stack, 'test-node', {
       mesh,
-      serviceDiscovery: appmesh.ServiceDiscovery.cloudMap({
-        service: service,
-      }),
+      serviceDiscovery: appmesh.ServiceDiscovery.cloudMap(service),
     });
 
     // THEN

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-node.ts
@@ -506,6 +506,7 @@ export = {
             },
           },
           )],
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
         });
 
         // THEN
@@ -551,6 +552,7 @@ export = {
               certificate: appmesh.TlsCertificate.file('path/to/certChain', 'path/to/privateKey'),
             },
           })],
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
         });
 
         // THEN
@@ -594,6 +596,7 @@ export = {
               certificate: appmesh.TlsCertificate.sds('secret_certificate'),
             },
           })],
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
         });
 
         // THEN
@@ -637,6 +640,7 @@ export = {
               certificate: appmesh.TlsCertificate.file('path/to/certChain', 'path/to/privateKey'),
             },
           })],
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
         });
 
         // THEN
@@ -682,6 +686,7 @@ export = {
             },
           }),
         ],
+        serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
       });
 
       // THEN
@@ -722,6 +727,7 @@ export = {
             },
           }),
         ],
+        serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
       });
 
       // THEN
@@ -761,6 +767,7 @@ export = {
             },
           }),
         ],
+        serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
       });
 
       // THEN
@@ -800,6 +807,7 @@ export = {
             },
           }),
         ],
+        serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
       });
 
       // THEN
@@ -871,6 +879,7 @@ export = {
           certificate: appmesh.TlsCertificate.file('path/to/certChain', 'path/to/privateKey'),
         },
       })],
+      serviceDiscovery: appmesh.ServiceDiscovery.dns('test'),
     });
 
     // WHEN
@@ -893,5 +902,59 @@ export = {
     }));
 
     test.done();
+  },
+
+  'When creating a VirtualNode': {
+    'with DNS service discovery': {
+      'should allow set response type'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN
+        new appmesh.VirtualNode(stack, 'test-node', {
+          mesh,
+          serviceDiscovery: appmesh.ServiceDiscovery.dns('test', appmesh.ResponseType.LOADBALANCER),
+        });
+
+        // THEN
+        expect(stack).to(haveResourceLike('AWS::AppMesh::VirtualNode', {
+          Spec: {
+            ServiceDiscovery: {
+              DNS: {
+                Hostname: 'test',
+                ResponseType: 'LOADBALANCER',
+              },
+            },
+          },
+        }));
+        test.done();
+      },
+    },
+
+    'with listener and without service discovery': {
+      'should throw an error'(test: Test) {
+        // GIVEN
+        const stack = new cdk.Stack();
+
+        const mesh = new appmesh.Mesh(stack, 'mesh', {
+          meshName: 'test-mesh',
+        });
+
+        // WHEN + THEN
+
+        test.throws(() => {
+          new appmesh.VirtualNode(stack, 'test-node', {
+            mesh,
+            listeners: [appmesh.VirtualNodeListener.http()],
+          });
+        }, /If you specify a listener, then you must specify service discovery information/);
+
+        test.done();
+      },
+    },
   },
 };


### PR DESCRIPTION
#### REV:
- Add new property `responseType` to DNS `ServiceDiscovery`
- Changing `.cloudMap()` factory method to accept positional argument
- Adding a runtime-error to check if the service discovery is defined when listener is specified

BREAKING CHANGE: `ServiceDiscovery.cloudMap()` method is changed to accept positional arguments.

#### Question for internal-peer
- I have not updated the `README` with changes because it did not contain any specific section with `ServiceDiscovery`, should I add a new section or child-section under "Crete a VirtualNode?

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
